### PR TITLE
chore(dependecies):update element-js to latest non breaking version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 
 # public directory
 dist/*
+docs-build

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"packages/interactions/*"
 	],
 	"dependencies": {
-		"@webtides/element-js": "0.3.0"
+		"@webtides/element-js": "0.4.3"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.10.4",

--- a/packages/elements/lazy-src/package.json
+++ b/packages/elements/lazy-src/package.json
@@ -35,7 +35,7 @@
 		"*.js"
 	],
 	"dependencies": {
-		"@webtides/element-js": "0.3.0",
+		"@webtides/element-js": "0.4.3",
 		"lozad": "^1.15.0"
 	},
 	"devDependencies": {

--- a/packages/elements/scroll-to-top/package.json
+++ b/packages/elements/scroll-to-top/package.json
@@ -35,7 +35,7 @@
 		"*.js"
 	],
 	"dependencies": {
-		"@webtides/element-js": "0.2.0"
+		"@webtides/element-js": "0.4.3"
 	},
 	"devDependencies": {
 		"@open-wc/demoing-storybook": "^1.13.3",

--- a/packages/elements/scroll-to/package.json
+++ b/packages/elements/scroll-to/package.json
@@ -35,7 +35,7 @@
 		"*.js"
 	],
 	"dependencies": {
-		"@webtides/element-js": "0.2.0"
+		"@webtides/element-js": "0.4.3"
 	},
 	"devDependencies": {
 		"@open-wc/demoing-storybook": "^1.13.3",

--- a/packages/elements/sticky-element/package.json
+++ b/packages/elements/sticky-element/package.json
@@ -31,7 +31,7 @@
 		"*.js"
 	],
 	"dependencies": {
-		"@webtides/element-js": "0.3.0"
+		"@webtides/element-js": "0.4.3"
 	},
 	"devDependencies": {
 		"@open-wc/demoing-storybook": "^1.13.3",

--- a/packages/elements/svg-use/package.json
+++ b/packages/elements/svg-use/package.json
@@ -31,7 +31,7 @@
 		"*.js"
 	],
 	"dependencies": {
-		"@webtides/element-js": "0.2.0"
+		"@webtides/element-js": "0.4.3"
 	},
 	"devDependencies": {
 		"@open-wc/demoing-storybook": "^1.13.3",

--- a/packages/forms/amount-field/package.json
+++ b/packages/forms/amount-field/package.json
@@ -31,7 +31,7 @@
     "*.js"
   ],
   "dependencies": {
-    "@webtides/element-js": "0.2.0",
+  	"@webtides/element-js": "0.4.3",
     "@webtides/form-field": "^0.1.0"
   },
   "devDependencies": {

--- a/packages/forms/checkbox-field/package.json
+++ b/packages/forms/checkbox-field/package.json
@@ -31,7 +31,7 @@
 		"*.js"
 	],
 	"dependencies": {
-		"@webtides/element-js": "0.2.0",
+		"@webtides/element-js": "0.4.3",
 		"@webtides/form-field": "^0.1.0"
 	},
 	"devDependencies": {

--- a/packages/forms/form-field/package.json
+++ b/packages/forms/form-field/package.json
@@ -31,7 +31,7 @@
 		"*.js"
 	],
 	"dependencies": {
-		"@webtides/element-js": "0.2.0"
+		"@webtides/element-js": "0.4.3"
 	},
 	"devDependencies": {
 		"@open-wc/demoing-storybook": "^1.13.3",

--- a/packages/forms/input-field/package.json
+++ b/packages/forms/input-field/package.json
@@ -31,7 +31,7 @@
 		"*.js"
 	],
 	"dependencies": {
-		"@webtides/element-js": "0.2.0",
+		"@webtides/element-js": "0.4.3",
 		"@webtides/form-field": "0.1.0"
 	},
 	"devDependencies": {

--- a/packages/forms/textarea-field/package.json
+++ b/packages/forms/textarea-field/package.json
@@ -31,7 +31,7 @@
 		"*.js"
 	],
 	"dependencies": {
-		"@webtides/element-js": "0.2.0",
+		"@webtides/element-js": "0.4.3",
 		"@webtides/form-field": "0.1.0"
 	},
 	"devDependencies": {

--- a/packages/interactions/accordion-element/package.json
+++ b/packages/interactions/accordion-element/package.json
@@ -31,7 +31,7 @@
 		"*.js"
 	],
 	"dependencies": {
-		"@webtides/element-js": "0.3.0"
+		"@webtides/element-js": "0.4.3"
 	},
 	"devDependencies": {
 		"@open-wc/demoing-storybook": "^1.13.3",

--- a/packages/interactions/accordion-group/package.json
+++ b/packages/interactions/accordion-group/package.json
@@ -31,7 +31,7 @@
 		"*.js"
 	],
 	"dependencies": {
-		"@webtides/element-js": "0.3.0",
+		"@webtides/element-js": "0.4.3",
 		"@webtides/accordion-element": "0.1.0"
 	},
 	"devDependencies": {

--- a/packages/interactions/carousel-element/package.json
+++ b/packages/interactions/carousel-element/package.json
@@ -32,7 +32,7 @@
 	],
 	"dependencies": {
 		"@glidejs/glide": "3.4.1",
-		"@webtides/element-js": "0.3.0"
+		"@webtides/element-js": "0.4.3"
 	},
 	"devDependencies": {
 		"@open-wc/demoing-storybook": "^1.13.3",

--- a/packages/interactions/dropdown-element/package.json
+++ b/packages/interactions/dropdown-element/package.json
@@ -31,7 +31,7 @@
     "*.js"
   ],
   "dependencies": {
-    "@webtides/element-js": "0.3.0"
+  	"@webtides/element-js": "0.4.3"
   },
   "devDependencies": {
     "@open-wc/demoing-storybook": "^1.13.3",

--- a/packages/interactions/slider-element/package.json
+++ b/packages/interactions/slider-element/package.json
@@ -31,7 +31,7 @@
 		"*.js"
 	],
 	"dependencies": {
-		"@webtides/element-js": "0.3.0"
+		"@webtides/element-js": "0.4.3"
 	},
 	"devDependencies": {
 		"@open-wc/demoing-storybook": "^1.13.3",

--- a/packages/interactions/tab-group/package.json
+++ b/packages/interactions/tab-group/package.json
@@ -31,7 +31,7 @@
     "*.js"
   ],
   "dependencies": {
-    "@webtides/element-js": "0.3.0"
+	"@webtides/element-js": "0.4.3"
   },
   "devDependencies": {
     "@open-wc/demoing-storybook": "^1.13.3",

--- a/packages/interactions/tab-link/package.json
+++ b/packages/interactions/tab-link/package.json
@@ -31,7 +31,7 @@
     "*.js"
   ],
   "dependencies": {
-    "@webtides/element-js": "0.3.0"
+  	"@webtides/element-js": "0.4.3"
   },
   "devDependencies": {
     "@open-wc/demoing-storybook": "^1.13.3",

--- a/packages/interactions/tab-panel/package.json
+++ b/packages/interactions/tab-panel/package.json
@@ -31,7 +31,7 @@
     "*.js"
   ],
   "dependencies": {
-    "@webtides/element-js": "0.3.0"
+  	"@webtides/element-js": "0.4.3"
   },
   "devDependencies": {
     "@open-wc/demoing-storybook": "^1.13.3",

--- a/packages/interactions/transition-classes/package.json
+++ b/packages/interactions/transition-classes/package.json
@@ -31,7 +31,7 @@
 		"*.js"
 	],
 	"dependencies": {
-		"@webtides/element-js": "0.2.0"
+		"@webtides/element-js": "0.4.3"
 	},
 	"devDependencies": {
 		"@open-wc/demoing-storybook": "^1.13.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3372,17 +3372,10 @@
   resolved "https://registry.yarnpkg.com/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.4.3.tgz#384f4f6d54563ba465fb4df21fe89e78a76fc530"
   integrity sha512-cV4+sAmshf8ysU2USutrSRYQkJzEYKHsRCGa0CkMElGpG5747VHtkfsW3NdVIBV/m2MDKXTDydT4lkrysH7IFA==
 
-"@webtides/element-js@0.2.0":
-  version "0.2.0"
-  resolved "https://npm.pkg.github.com/download/@webtides/element-js/0.2.0/87733784b3d7a9183d35120c840365b707b34effd6b601b1adbe565b6955532c#bdc216c5f8b61230873bc2c77eef5665f012d4ca"
-  integrity sha512-TmUqR30ylaTXSo+L1FY7NsgJOYd95V1XXJzJp4/cJNlj47i+qkrQQmLy1mIMZ1yJJ8m83kdUJfn5tg765F4TRQ==
-  dependencies:
-    lit-html "^1.2.1"
-
-"@webtides/element-js@0.3.0":
-  version "0.3.0"
-  resolved "https://npm.pkg.github.com/download/@webtides/element-js/0.3.0/7c263fcd17e7fdf6eb4ea59c529a2fb1426a00072efa8b9b710e1805e641323b#3d0046c3d6e83b9361c00b62c42b73e4d8f36077"
-  integrity sha512-1xPTNEfuSLocT5G6boLjJC6y9LZyggsA147WJszWN/E5Es5pGtLG8ruzagZZy+NcF2sHJWh/ThOoKhDBi0D2Og==
+"@webtides/element-js@0.4.3":
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/@webtides/element-js/-/element-js-0.4.3.tgz#18f492569aef260f41a69b1ae69c337ef934ad2b"
+  integrity sha512-+z3eosEsTCT14kPHMEgaXTy+F07qZN13QrkZCvAaoxEgQ9op13++k70XGms5piK1kblXHngerX4K586q53KRVw==
   dependencies:
     lit-html "^1.2.1"
 


### PR DESCRIPTION
No breaking changes in latest element-js version afaik . checks fine, storbook looks good.

We have some more critical updates (storybook, lerna) to do but i wanted to keep the change as small as possible.
(Maybe we should make this step while ditching the monorepo as discussed)