### PR TITLE
ci(dependabot): exclude named-group patterns from dev-deps-patch catch-all

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,18 @@ updates:
         dependency-type: development
         update-types:
           - patch
+        # Catch-all for leftover dev patches. Without these excludes it
+        # siphons packages owned by the named groups above (e.g. @vitest/*
+        # landed here instead of the vitest group), splitting a single
+        # version line across two PRs that then conflict on merge.
+        exclude-patterns:
+          - 'storybook'
+          - '@storybook/*'
+          - 'vitest'
+          - '@vitest/*'
+          - 'eslint'
+          - 'eslint-*'
+          - '@eslint/*'
     ignore:
       # Pinned at ~3.6.2 — 3.7+ added an exports map that blocks the
       # deep imports the carousel-element ShadowDOM patches depend on.


### PR DESCRIPTION
## What

Adds `exclude-patterns` to the `dev-deps-patch` Dependabot group so it no longer siphons packages that belong to the dedicated `storybook` / `vitest` / `eslint` groups.

## Why

`dev-deps-patch` matches by `dependency-type: development` + `update-types: [patch]` with no `patterns`, making it a catch-all. Dependabot's docs note a catch-all needs `exclude-patterns` to avoid overlap. Without it, the last weekly run split `@vitest/*` into the dev-deps-patch PR (#46) while `vitest` core stayed in the vitest PR (#44) — two PRs bumping the same `4.1.x` line that **conflicted on merge** (had to be resolved by hand).

## Effect

Future runs keep `vitest` + `@vitest/*` (and the storybook / eslint families) together in their named groups; `dev-deps-patch` only collects genuinely ungrouped dev patches.

No runtime impact — CI config only.