### PR TITLE
feat(dialog): add el-dialog modal built on native <dialog>

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ storybook-static/
 # Generated coverage report (built by `npm run test:coverage`, set in vitest.config.js)
 test/coverage/
 
+# Transient debug attachments from Vitest browser-mode runs
+.vitest-attachments/
+
 # Generated type declarations (built by `npm run build:types`, also via prepack)
 types/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/) and this 
 ### Components
 
 - Added: new `el-button` component — a themeable button modelled on Shoelace's `<sl-button>` (variants, sizes, outline/pill/circle, caret, loading, prefix/suffix slots, link mode).
+- Added: new `el-dialog` component — a modal dialog built on the native `<dialog>` element (platform-provided focus trap, background `inert`, focus restore and `<form method="dialog">` auto-close), with an animated, cancelable open/close lifecycle and ref-counted body-scroll locking that compensates for the removed scrollbar width (no layout shift on open). API modelled on Shoelace's `<sl-dialog>`.
 - Added: new `el-radio-field` component — a single-choice radio group extending `FormField`, rendering a native `<fieldset>`/`<legend>` of mutually-exclusive radios from an `options` array (strings or `{ value, label?, disabled? }`) with a custom, headless-by-default indicator. Inherits the `input-change` event and `touched`/`valid`/`invalid` states.
 - Added: new `el-switch-field` component — an on/off toggle extending `FormField`, rendering a native `<input type="checkbox">` with `role="switch"` behind a custom, headless-by-default track/thumb. Reflects `checked`, adds a `checked` custom state, and inherits the `input-change` event and `touched`/`valid`/`invalid` states.
 - Added: new `el-password-field` component — a masked password input extending `InputField`, pinning the input `type` to `password` (flipping to `text` while revealed) and adding an optional show/hide reveal button (`password-toggle`, default on). Inherits the `input-change` event and `touched`/`valid`/`invalid` states. All three shipped themes decorate its native input identically to `el-input-field`, so themed password and text fields match.
@@ -22,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/) and this 
 
 ### Theming
 
+- Added: dialog tokens (`--el-dialog-width`, `--el-dialog-overlay-background`) wired into all three shipped themes (default / high-contrast / sketchy), so themed `el-dialog`s get a visible, per-theme overlay scrim. Unthemed dialogs keep a `transparent` backdrop (headless). Documented in the Storybook _Docs / Theming_ token reference.
 - Added: opt-in default theme stylesheet at `@webtides/element-library/themes/default.css`. Defines the `--el-*` token vocabulary at `:root` with `light-dark()` color values; without it imported, components stay headless.
 - Added: opt-in high-contrast theme stylesheet at `@webtides/element-library/themes/high-contrast.css`. Same token contract, accessibility-leaning identity: near-black/white surfaces, 2px borders, 3px focus rings, no shadows, larger touch targets. Supports both color schemes via `light-dark()`.
 - Added: Storybook toolbar gains a "Theme" switch (None / Default / High contrast) and a "Color scheme" switch (System / Light / Dark) for previewing themed and unthemed states.

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Each theme defines the library's `--el-*` design-token contract at `:root` and u
 | button             | A themeable button with variants, sizes, icon slots, caret and loading        | `0.1.0` |
 | carousel           | A carousel element that wraps the glide.js library for sliding elements       | `0.1.1` |
 | checkbox-field     |                                                                               | `0.1.1` |
+| dialog             | A modal dialog built on the native `<dialog>` element                         | `0.1.0` |
 | dropdown           | A dropdown element                                                            | `0.1.0` |
 | form-field         |                                                                               | `0.1.0` |
 | input-field        |                                                                               | `0.1.0` |
@@ -82,7 +83,6 @@ Each theme defines the library's `--el-*` design-token contract at `:root` and u
 | modal-element        |                                                 | TBD  |
 | bottom-sheet         |                                                 | TBD  |
 | side-sheet           |                                                 | TBD  |
-| dialog-element       |                                                 | TBD  |
 | notification-element | Toast, Alert ?!                                 | TBD  |
 | breadcrumb-element   |                                                 | TBD  |
 | horizontal-scroll    |                                                 | TBD  |

--- a/all.js
+++ b/all.js
@@ -4,6 +4,7 @@ import './src/components/amount-field/amount-field.define.js';
 import './src/components/button/button.define.js';
 import './src/components/carousel/carousel.define.js';
 import './src/components/checkbox-field/checkbox-field.define.js';
+import './src/components/dialog/dialog.define.js';
 import './src/components/dropdown/dropdown.define.js';
 import './src/components/form-field/form-field.define.js';
 import './src/components/input-field/input-field.define.js';

--- a/src/components/dialog/dialog.changelog.md
+++ b/src/components/dialog/dialog.changelog.md
@@ -1,0 +1,22 @@
+# Change Log
+
+All notable changes to this component live here. Versions refer to the parent `@webtides/element-library` release (see root [`CHANGELOG.md`](../../../CHANGELOG.md)); components no longer version independently.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/).
+
+<!--
+   When your PR touches this component, add an entry under Unreleased and
+   mirror it (prefixed with the component name) in root CHANGELOG.md.
+   Uncomment headings as needed.
+-->
+
+## Unreleased
+
+### Added
+
+- Initial release of `el-dialog` — a modal dialog built on the native `<dialog>` element. The platform provides focus trapping, background `inert`, top-layer rendering, focus restoration and `<form method="dialog">` auto-close; the component adds an animated, cancelable open/close lifecycle and ref-counted body-scroll locking that compensates for the removed scrollbar width (no layout shift on open). API modelled on Shoelace's `<sl-dialog>`.
+- Properties `open` (reflected), `label`, `no-header` (reflected) and `close-label`.
+- Methods `show()` / `hide()` (both resolve after their transition) and `requestClose(source)`.
+- Events `dialog-show`, `dialog-after-show`, `dialog-hide`, `dialog-after-hide`, the cancelable `dialog-initial-focus`, and the cancelable `dialog-request-close` (with `detail.source` of `'close-button' | 'keyboard' | 'overlay'`).
+- Slots: default (body), `label`, `header-actions` and `footer` (collapses when empty).
+- CSS parts `base`, `header`, `title`, `header-actions`, `close-button`, `body`, `footer`; the `open` custom state; and the `--el-dialog-width`, `--el-dialog-overlay-background` and `--el-dialog-enter-offset` tokens on top of the shared `--el-*` vocabulary.

--- a/src/components/dialog/dialog.define.js
+++ b/src/components/dialog/dialog.define.js
@@ -1,0 +1,3 @@
+import { define } from './dialog.js';
+
+define();

--- a/src/components/dialog/dialog.events.js
+++ b/src/components/dialog/dialog.events.js
@@ -1,0 +1,8 @@
+export default {
+    SHOW: 'dialog-show',
+    AFTER_SHOW: 'dialog-after-show',
+    HIDE: 'dialog-hide',
+    AFTER_HIDE: 'dialog-after-hide',
+    INITIAL_FOCUS: 'dialog-initial-focus',
+    REQUEST_CLOSE: 'dialog-request-close',
+};

--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -1,0 +1,271 @@
+import { TemplateElement, html, defineElement, spreadAttributes } from '@webtides/element-js';
+import style from './dialog.style.js';
+import Events from './dialog.events.js';
+import { lockBodyScroll, unlockBodyScroll } from '../../utils/body-scroll.js';
+import { afterTransition, nextFrame } from '../../utils/transitions.js';
+
+/**
+ * A modal dialog built on the native `<dialog>` element, so the platform owns focus trapping,
+ * background `inert`, top-layer rendering, focus restoration and `<form method="dialog">`
+ * auto-close. The component adds an animated, cancelable open/close lifecycle and ref-counted
+ * body-scroll locking on top. API modelled on Shoelace's `<sl-dialog>`.
+ *
+ * @element el-dialog
+ *
+ * @fires {CustomEvent} dialog-show - Fired when the dialog starts to open.
+ * @fires {CustomEvent} dialog-after-show - Fired once the open transition has finished.
+ * @fires {CustomEvent} dialog-hide - Fired when the dialog starts to close.
+ * @fires {CustomEvent} dialog-after-hide - Fired once the close transition has finished.
+ * @fires {CustomEvent} dialog-initial-focus - Fired after the dialog has been opened and the
+ *   platform has moved focus inside it. Cancelable: call `preventDefault()` to take over focus.
+ * @fires {CustomEvent<{ source: 'close-button' | 'keyboard' | 'overlay' }>} dialog-request-close -
+ *   Fired before the dialog closes in response to the close button, `Escape`, or an overlay
+ *   click. Cancelable: call `preventDefault()` to keep the dialog open.
+ *
+ * @slot - The dialog's main content (body).
+ * @slot label - The dialog's title. Takes precedence over the `label` attribute.
+ * @slot header-actions - Optional controls rendered in the header, before the close button.
+ * @slot footer - Footer content, typically action buttons. The footer collapses when empty.
+ *
+ * @csspart base - The native `<dialog>` element — the panel surface (background, border, radius,
+ *   elevation). The overlay is its `::backdrop` pseudo-element.
+ * @csspart header - The header row wrapping the title, header actions and close button.
+ * @csspart title - The title heading.
+ * @csspart header-actions - The container for the `header-actions` slot.
+ * @csspart close-button - The built-in close button.
+ * @csspart body - The scrollable body wrapping the default slot.
+ * @csspart footer - The footer wrapping the `footer` slot.
+ *
+ * @cssstate open - Set while the dialog is open. Style with `:host(:state(open))` or
+ *   `el-dialog:state(open)` from outside.
+ *
+ * @property {boolean} open - Whether the dialog is open. Reflected to the `open` attribute.
+ * @property {string} label - The dialog's title (used when the `label` slot is empty); also the
+ *   accessible name when `no-header` is set.
+ * @property {boolean} noHeader - Removes the header (title and built-in close button). Provide
+ *   your own dismissal when set. Reflected to the `no-header` attribute.
+ * @property {string} closeLabel - Accessible label for the built-in close button. Default `'Close'`.
+ */
+export default class Dialog extends TemplateElement {
+    constructor() {
+        super({
+            shadowRender: true,
+            styles: [style],
+            propertyOptions: { open: { reflect: true }, noHeader: { reflect: true } },
+        });
+    }
+
+    properties() {
+        return {
+            open: false,
+            label: '',
+            noHeader: false,
+            closeLabel: 'Close',
+        };
+    }
+
+    connected() {
+        // The watcher does not run during initial hydration, so honour a declaratively-open dialog here.
+        if (this.open) {
+            this._internals.states.add('open');
+            this._applyOpen();
+        }
+    }
+
+    disconnected() {
+        // Release the scroll lock we took if the dialog is torn down while open.
+        if (this.$refs.dialog?.open) {
+            unlockBodyScroll();
+        }
+    }
+
+    watch() {
+        return {
+            open: (open) => {
+                if (open) {
+                    this._internals.states.add('open');
+                    this._applyOpen();
+                } else {
+                    this._internals.states.delete('open');
+                    this._applyClose();
+                }
+            },
+        };
+    }
+
+    events() {
+        return {
+            '[data-dialog-close]': {
+                click: () => this.requestClose('close-button'),
+            },
+            "slot[name='footer']": {
+                slotchange: (event) => this._syncFooter(event.target),
+            },
+            "[part~='base']": {
+                // The UA fires `cancel` on Escape; route it through our cancelable close flow.
+                cancel: (event) => {
+                    event.preventDefault();
+                    this.requestClose('keyboard');
+                },
+                click: (event) => this._handleOverlayClick(event),
+            },
+        };
+    }
+
+    /**
+     * Opens the dialog.
+     * @returns {Promise<void>} Resolves after the open transition has finished.
+     */
+    show() {
+        if (this.open) return Promise.resolve();
+        const done = this._once(Events.AFTER_SHOW);
+        this.open = true;
+        return done;
+    }
+
+    /**
+     * Closes the dialog.
+     * @returns {Promise<void>} Resolves after the close transition has finished.
+     */
+    hide() {
+        if (!this.open) return Promise.resolve();
+        const done = this._once(Events.AFTER_HIDE);
+        this.open = false;
+        return done;
+    }
+
+    /**
+     * Requests that the dialog close, emitting the cancelable `dialog-request-close` event. When a
+     * listener calls `preventDefault()` the dialog stays open and plays a short deny animation.
+     * @param {'close-button' | 'keyboard' | 'overlay'} source - What triggered the request.
+     * @returns {void}
+     */
+    requestClose(source) {
+        // element-js's dispatch() swallows the dispatchEvent() return value, so build the cancelable
+        // event by hand to read defaultPrevented.
+        const event = new CustomEvent(Events.REQUEST_CLOSE, {
+            bubbles: true,
+            composed: true,
+            cancelable: true,
+            detail: { source },
+        });
+        this.dispatchEvent(event);
+
+        if (event.defaultPrevented) {
+            this._denyClose();
+            return;
+        }
+        this.open = false;
+    }
+
+    /** @private */
+    async _applyOpen() {
+        const dialog = this.$refs.dialog;
+        if (!dialog || dialog.open) return;
+
+        this.dispatch(Events.SHOW);
+        lockBodyScroll();
+        dialog.showModal();
+        // The platform has now moved focus inside the dialog; let consumers redirect it.
+        this.dispatch(Events.INITIAL_FOCUS);
+
+        await nextFrame();
+        dialog.classList.add('showing');
+        await afterTransition(dialog);
+        this.dispatch(Events.AFTER_SHOW);
+    }
+
+    /** @private */
+    async _applyClose() {
+        const dialog = this.$refs.dialog;
+        if (!dialog || !dialog.open) return;
+
+        this.dispatch(Events.HIDE);
+        dialog.classList.remove('showing');
+        await afterTransition(dialog);
+        dialog.close();
+        unlockBodyScroll();
+        this.dispatch(Events.AFTER_HIDE);
+    }
+
+    /** @private */
+    _handleOverlayClick(event) {
+        const dialog = this.$refs.dialog;
+        if (event.target !== dialog) return;
+        // A click whose target is the dialog itself is either the backdrop or the element's own
+        // padding. Treat it as an overlay click only when it lands outside the panel box.
+        const rect = dialog.getBoundingClientRect();
+        const inside =
+            event.clientX >= rect.left &&
+            event.clientX <= rect.right &&
+            event.clientY >= rect.top &&
+            event.clientY <= rect.bottom;
+        if (!inside) this.requestClose('overlay');
+    }
+
+    /** @private */
+    _denyClose() {
+        const dialog = this.$refs.dialog;
+        if (!dialog?.animate) return;
+        if (window.matchMedia?.('(prefers-reduced-motion: reduce)').matches) return;
+        dialog.animate([{ transform: 'scale(1)' }, { transform: 'scale(1.02)' }, { transform: 'scale(1)' }], {
+            duration: 150,
+            easing: 'ease',
+        });
+    }
+
+    /** @private */
+    _syncFooter(slot) {
+        const hasContent = slot
+            .assignedNodes({ flatten: true })
+            .some((node) => node.nodeType === Node.ELEMENT_NODE || node.textContent.trim() !== '');
+        this.$refs.footer?.classList.toggle('is-empty', !hasContent);
+    }
+
+    /** @private */
+    _once(name) {
+        return new Promise((resolve) => this.addEventListener(name, () => resolve(), { once: true }));
+    }
+
+    /** @private */
+    headerTemplate() {
+        return html`
+            <div part="header">
+                <h2 part="title" id="title"><slot name="label">${this.label}</slot></h2>
+                <span part="header-actions"><slot name="header-actions"></slot></span>
+                <button part="close-button" type="button" aria-label="${this.closeLabel}" data-dialog-close>
+                    <svg
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        aria-hidden="true"
+                    >
+                        <line x1="18" y1="6" x2="6" y2="18"></line>
+                        <line x1="6" y1="6" x2="18" y2="18"></line>
+                    </svg>
+                </button>
+            </div>
+        `;
+    }
+
+    template() {
+        const labelling = this.noHeader ? { 'aria-label': this.label || undefined } : { 'aria-labelledby': 'title' };
+
+        return html`
+            <dialog ref="dialog" part="base" ${spreadAttributes(labelling)}>
+                ${this.noHeader ? '' : this.headerTemplate()}
+                <div part="body"><slot></slot></div>
+                <div part="footer" ref="footer" class="is-empty"><slot name="footer"></slot></div>
+            </dialog>
+        `;
+    }
+}
+
+export function define() {
+    defineElement('el-dialog', Dialog);
+}
+
+export { Events };

--- a/src/components/dialog/dialog.readme.md
+++ b/src/components/dialog/dialog.readme.md
@@ -1,0 +1,122 @@
+# Dialog
+
+`dialog` is a modal dialog built on the native `<dialog>` element. The platform handles focus trapping, making the background `inert`, top-layer rendering (no `z-index` juggling), focus restoration on close, and `<form method="dialog">` auto-close. On top of that the component adds an animated, cancelable open/close lifecycle and ref-counted body-scroll locking.
+
+It is headless by default — without a theme it imposes no colors, borders, shadows or backdrop. Opt in by importing a theme (or setting the `--el-*` tokens yourself).
+
+## How to use
+
+#### Install
+
+```sh
+npm i --save @webtides/element-library
+```
+
+#### Use
+
+```js
+import '@webtides/element-library/dialog/define';
+```
+
+```html
+<button type="button" onclick="document.querySelector('el-dialog').show()">Open</button>
+
+<el-dialog label="Confirm">
+    <p>Are you sure you want to continue?</p>
+    <button slot="footer" type="button" onclick="this.closest('el-dialog').hide()">Cancel</button>
+    <button slot="footer" type="button" onclick="this.closest('el-dialog').hide()">OK</button>
+</el-dialog>
+```
+
+Open and close it imperatively with the `show()` / `hide()` methods (both return a promise that resolves once the transition finishes), or by toggling the `open` attribute/property.
+
+## API
+
+#### Properties/Attributes
+
+| Name | Type | Default | Description |
+| --- | --- | --- | --- |
+| `open` | `boolean` | `false` | Whether the dialog is open. Reflected to the `open` attribute. |
+| `label` | `string` | `''` | The dialog's title (used when the `label` slot is empty); the accessible name when headless. |
+| `no-header` | `boolean` | `false` | Removes the header (title and built-in close button). Reflected to the `no-header` attribute. |
+| `close-label` | `string` | `'Close'` | Accessible label for the built-in close button. |
+
+#### Methods
+
+| Name                   | Returns         | Description                                                    |
+| ---------------------- | --------------- | -------------------------------------------------------------- |
+| `show()`               | `Promise<void>` | Opens the dialog; resolves after the open transition.          |
+| `hide()`               | `Promise<void>` | Closes the dialog; resolves after the close transition.        |
+| `requestClose(source)` | `void`          | Requests a close, emitting the cancelable request-close event. |
+
+#### Events
+
+| Name | Cancelable | Detail | Description |
+| --- | --- | --- | --- |
+| `dialog-show` | no | — | The dialog starts to open. |
+| `dialog-after-show` | no | — | The open transition has finished. |
+| `dialog-hide` | no | — | The dialog starts to close. |
+| `dialog-after-hide` | no | — | The close transition has finished. |
+| `dialog-initial-focus` | yes | — | Focus has moved into the dialog; prevent to override. |
+| `dialog-request-close` | yes | `{ source: 'close-button' \| 'keyboard' \| 'overlay' }` | A close was requested; `preventDefault()` to keep open. |
+
+#### Slots
+
+| Name             | Description                                                      |
+| ---------------- | ---------------------------------------------------------------- |
+| _(default)_      | The dialog's main content (body).                                |
+| `label`          | The dialog's title. Takes precedence over the `label` attribute. |
+| `header-actions` | Optional controls in the header, before the close button.        |
+| `footer`         | Footer content, typically action buttons. Collapses when empty.  |
+
+#### CSS Parts
+
+| Name             | Description                                                                        |
+| ---------------- | ---------------------------------------------------------------------------------- |
+| `base`           | The native `<dialog>` — the panel surface. The overlay is its `::backdrop` pseudo. |
+| `header`         | The header row (title, header actions, close button).                              |
+| `title`          | The title heading.                                                                 |
+| `header-actions` | The container for the `header-actions` slot.                                       |
+| `close-button`   | The built-in close button.                                                         |
+| `body`           | The scrollable body wrapping the default slot.                                     |
+| `footer`         | The footer wrapping the `footer` slot.                                             |
+
+#### CSS States
+
+| Name   | Description                                                                       |
+| ------ | --------------------------------------------------------------------------------- |
+| `open` | Present on the host while the dialog is open. Style with `el-dialog:state(open)`. |
+
+#### CSS Custom Properties
+
+Headless by default; reads the library's `--el-*` design tokens (e.g. `--el-color-bg`, `--el-color-border`, `--el-radius-lg`, `--el-shadow-lg`, `--el-space-4`, `--el-duration-md`, `--el-ease`). Two dialog-specific tokens fine-tune the surface:
+
+| Name                             | Default       | Description                                 |
+| -------------------------------- | ------------- | ------------------------------------------- |
+| `--el-dialog-width`              | `31rem`       | The dialog's width.                         |
+| `--el-dialog-overlay-background` | `transparent` | The `::backdrop` background.                |
+| `--el-dialog-enter-offset`       | `0.5rem`      | Vertical offset the panel animates in from. |
+
+See the Storybook _Docs / Theming_ page for the full token reference.
+
+## Accessibility
+
+- Opening calls `showModal()`, so focus is trapped, the rest of the page is `inert`, and focus is restored to the previously focused element on close.
+- The dialog is labelled by its title; with `no-header`, set `label` to provide the accessible name.
+- Initial focus honours the native `autofocus` attribute on a child. Listen for `dialog-initial-focus` and `preventDefault()` to manage focus yourself.
+- `Escape` is routed through the cancelable `dialog-request-close` event so it can be blocked.
+- Both shipped themes collapse the open/close transition under `prefers-reduced-motion: reduce`.
+
+## Scroll locking
+
+While a dialog is open, page scrolling is locked (ref-counted, so stacked dialogs cooperate). Hiding the scrollbar would normally widen the page and cause a layout shift, so the dialog pads the document by the removed scrollbar's width to keep the content steady. This is a no-op on overlay-scrollbar systems (e.g. macOS), where the scrollbar takes no layout space.
+
+This compensation covers normal page content, but `position: fixed` elements pinned to the right edge (a floating action button, a sticky toolbar) are positioned against the viewport and still shift by the scrollbar width when it disappears. To avoid that entirely, reserve the scrollbar gutter on your document up front:
+
+```css
+:root {
+    scrollbar-gutter: stable;
+}
+```
+
+With the gutter always reserved, the scrollbar's space never changes between locked and unlocked, so neither the page nor fixed elements move.

--- a/src/components/dialog/dialog.stories.js
+++ b/src/components/dialog/dialog.stories.js
@@ -1,0 +1,138 @@
+import { userEvent, expect, waitFor } from 'storybook/test';
+import { html } from '@webtides/element-js';
+import readme from './dialog.readme.md?raw';
+import { define } from './dialog.js';
+define();
+
+export default {
+    title: 'Components/Dialog',
+    component: 'el-dialog',
+    tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component: readme,
+            },
+        },
+    },
+    args: {
+        label: 'Dialog title',
+    },
+};
+
+export const Dialog = {
+    parameters: {
+        docs: {
+            description: {
+                story: 'A modal dialog with a header, scrollable body and footer actions. Built on the native `<dialog>` element, so focus is trapped, the background is `inert`, and focus returns to the trigger on close. Closes on the close button, `Escape`, or an overlay click.',
+            },
+        },
+    },
+    render: ({ label }) => html`
+        <button type="button" onclick="this.nextElementSibling.show()">Open dialog</button>
+        <el-dialog label="${label}">
+            <p>This is a native, accessible modal dialog. Try tabbing — focus stays inside.</p>
+            <p>Press <kbd>Escape</kbd>, click the close button, or click outside to dismiss it.</p>
+            <button slot="footer" type="button" onclick="this.closest('el-dialog').hide()">Cancel</button>
+            <button slot="footer" type="button" onclick="this.closest('el-dialog').hide()">OK</button>
+        </el-dialog>
+    `,
+    play: async ({ canvasElement, step }) => {
+        const dialog = canvasElement.querySelector('el-dialog');
+        const trigger = canvasElement.querySelector('button');
+
+        await step('opens when the trigger is clicked', async () => {
+            await userEvent.click(trigger);
+            await waitFor(() => expect(dialog.open).toBe(true));
+        });
+
+        await step('closes via the built-in close button', async () => {
+            // Synthetic key events don't trigger the UA's native dialog cancel, so drive the
+            // close button (which routes through the same request-close flow as Escape).
+            const closeButton = dialog.shadowRoot.querySelector('[data-dialog-close]');
+            await userEvent.click(closeButton);
+            await waitFor(() => expect(dialog.open).toBe(false));
+        });
+    },
+};
+
+export const NoHeader = {
+    name: 'No header',
+    parameters: {
+        docs: {
+            description: {
+                story: 'With `no-header`, the title and built-in close button are removed — you supply your own dismissal. The `label` still provides the accessible name.',
+            },
+        },
+    },
+    render: ({ label }) => html`
+        <button type="button" onclick="this.nextElementSibling.show()">Open dialog</button>
+        <el-dialog label="${label}" no-header="true">
+            <p>This dialog has no header. Provide your own way to close it.</p>
+            <button slot="footer" type="button" onclick="this.closest('el-dialog').hide()">Done</button>
+        </el-dialog>
+    `,
+};
+
+export const Scrolling = {
+    name: 'Scrolling body',
+    parameters: {
+        docs: {
+            description: {
+                story: 'When the content exceeds the dialog height, the body scrolls while the header and footer stay put.',
+            },
+        },
+    },
+    render: ({ label }) => html`
+        <button type="button" onclick="this.nextElementSibling.show()">Open dialog</button>
+        <el-dialog label="${label}">
+            ${Array.from(
+                { length: 30 },
+                (_, i) => html`<p>Paragraph ${i + 1} — scroll to see the footer stay pinned.</p>`,
+            )}
+            <button slot="footer" type="button" onclick="this.closest('el-dialog').hide()">Close</button>
+        </el-dialog>
+    `,
+};
+
+export const PreventClose = {
+    name: 'Prevent close',
+    parameters: {
+        docs: {
+            description: {
+                story: 'A `dialog-request-close` listener can call `preventDefault()` to keep the dialog open — here, overlay clicks and `Escape` are blocked, so only the explicit footer button closes it.',
+            },
+        },
+    },
+    render: ({ label }) => html`
+        <button type="button" onclick="this.nextElementSibling.show()">Open dialog</button>
+        <el-dialog label="${label}">
+            <p>Escape and overlay clicks are blocked. Use the button below to close.</p>
+            <button slot="footer" type="button" onclick="this.closest('el-dialog').hide()">I understand</button>
+        </el-dialog>
+    `,
+    play: async ({ canvasElement, step }) => {
+        const dialog = canvasElement.querySelector('el-dialog');
+        const trigger = canvasElement.querySelector('button');
+        dialog.addEventListener('dialog-request-close', (event) => {
+            if (event.detail.source !== 'close-button') event.preventDefault();
+        });
+
+        await step('opens when the trigger is clicked', async () => {
+            await userEvent.click(trigger);
+            await waitFor(() => expect(dialog.open).toBe(true));
+        });
+
+        await step('stays open when a keyboard close is requested', async () => {
+            // Same flow the UA's Escape-driven cancel takes; the listener prevents it, so it stays open.
+            dialog.requestClose('keyboard');
+            await expect(dialog.open).toBe(true);
+        });
+
+        await step('closes via the explicit footer button', async () => {
+            const footerButton = dialog.querySelector('[slot="footer"]');
+            await userEvent.click(footerButton);
+            await waitFor(() => expect(dialog.open).toBe(false));
+        });
+    },
+};

--- a/src/components/dialog/dialog.style.js
+++ b/src/components/dialog/dialog.style.js
@@ -1,0 +1,124 @@
+const css = String.raw;
+
+export default css`
+    :host {
+        display: contents;
+    }
+
+    /*
+     * The native <dialog> is the top-layer surface (the "panel"). It is headless by default —
+     * every visual token falls back to a null-ish value so an unthemed dialog imposes nothing.
+     */
+    dialog {
+        margin: auto;
+        padding: 0;
+        border: var(--el-border-width, 0) solid var(--el-color-border, transparent);
+        border-radius: var(--el-radius-lg, 0);
+        background: var(--el-color-bg, transparent);
+        color: var(--el-color-fg, inherit);
+        box-shadow: var(--el-shadow-lg, none);
+
+        width: var(--el-dialog-width, 31rem);
+        max-width: calc(100vw - 2 * var(--el-space-4, 1rem));
+        max-height: calc(100vh - 2 * var(--el-space-4, 1rem));
+
+        opacity: 0;
+        transform: translateY(var(--el-dialog-enter-offset, 0.5rem));
+        transition:
+            opacity var(--el-duration-md, 0s) var(--el-ease, ease),
+            transform var(--el-duration-md, 0s) var(--el-ease, ease);
+    }
+
+    /* Lay the box out only while open so the UA's \`dialog:not([open]) { display: none }\` still hides it. */
+    dialog[open] {
+        display: flex;
+        flex-direction: column;
+    }
+
+    dialog.showing {
+        opacity: 1;
+        transform: none;
+    }
+
+    dialog::backdrop {
+        background: var(--el-dialog-overlay-background, transparent);
+        opacity: 0;
+        transition: opacity var(--el-duration-md, 0s) var(--el-ease, ease);
+    }
+
+    dialog.showing::backdrop {
+        opacity: 1;
+    }
+
+    [part~='header'] {
+        display: flex;
+        align-items: center;
+        gap: var(--el-space-2, 0.5rem);
+        padding: var(--el-space-4, 1rem);
+    }
+
+    [part~='title'] {
+        flex: 1 1 auto;
+        margin: 0;
+        font-size: var(--el-font-size-lg, 1.125rem);
+        font-weight: var(--el-font-weight-semibold, 600);
+        line-height: 1.2;
+    }
+
+    [part~='header-actions'] {
+        display: flex;
+        flex: 0 0 auto;
+        align-items: center;
+        gap: var(--el-space-2, 0.5rem);
+    }
+
+    [part~='close-button'] {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        padding: 0;
+        border: none;
+        border-radius: var(--el-radius-md, 0);
+        background: transparent;
+        color: inherit;
+        cursor: pointer;
+        line-height: 0;
+    }
+
+    [part~='close-button'] svg {
+        width: 1.25rem;
+        height: 1.25rem;
+    }
+
+    [part~='body'] {
+        flex: 1 1 auto;
+        overflow: auto;
+        padding: var(--el-space-4, 1rem);
+    }
+
+    /* Header present: let the header own the top padding so the body doesn't double it. */
+    [part~='header'] + [part~='body'] {
+        padding-top: 0;
+    }
+
+    [part~='footer'] {
+        display: flex;
+        flex: 0 0 auto;
+        justify-content: flex-end;
+        gap: var(--el-space-2, 0.5rem);
+        padding: var(--el-space-4, 1rem);
+        padding-top: 0;
+    }
+
+    /* Collapse the footer entirely when nothing is slotted into it. */
+    [part~='footer']:not(:has(*)) {
+        display: none;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+        dialog,
+        dialog::backdrop {
+            transition-duration: 0s;
+        }
+    }
+`;

--- a/src/components/dialog/dialog.test.feature.js
+++ b/src/components/dialog/dialog.test.feature.js
@@ -1,0 +1,141 @@
+import { describe, it, expect } from 'vitest';
+import axe from 'axe-core';
+import { fixture, nextFrame, oneEvent } from '../../test-helpers.js';
+import { define } from './dialog.js';
+define();
+
+const dialogFixture = (attrs = '') =>
+    fixture(`
+        <el-dialog label="Dialog title" ${attrs}>
+            <p>Dialog body content.</p>
+            <button slot="footer" type="button">Close</button>
+        </el-dialog>
+    `);
+
+describe('Feature | Dialog', () => {
+    it('can connect without errors', async () => {
+        const el = await fixture(`<el-dialog></el-dialog>`);
+        await nextFrame();
+        expect(el.shadowRoot.querySelector('[part="base"]')).not.toBeNull();
+    });
+
+    it('opens and closes via show() / hide()', async () => {
+        const el = await dialogFixture();
+        const dialog = el.shadowRoot.querySelector('dialog');
+
+        await el.show();
+        expect(el.open).toBe(true);
+        expect(dialog.open).toBe(true);
+        expect(el.matches(':state(open)')).toBe(true);
+
+        await el.hide();
+        expect(el.open).toBe(false);
+        expect(dialog.open).toBe(false);
+        expect(el.matches(':state(open)')).toBe(false);
+    });
+
+    it('moves focus into the dialog when opened', async () => {
+        const el = await dialogFixture();
+        await el.show();
+        // Focus lands inside the shadow DOM, so the host becomes document.activeElement.
+        expect(document.activeElement).toBe(el);
+        await el.hide();
+    });
+
+    it('locks document scroll while open and restores it (with padding) on close', async () => {
+        const root = document.documentElement;
+        const overflowBefore = root.style.overflow;
+        const paddingBefore = root.style.paddingRight;
+
+        const el = await dialogFixture();
+        await el.show();
+        // Scroll is locked while open; the scrollbar-compensation padding never goes negative.
+        expect(root.style.overflow).toBe('hidden');
+        expect(parseFloat(root.style.paddingRight) || 0).toBeGreaterThanOrEqual(0);
+
+        await el.hide();
+        // Both the overflow and the padding are returned to exactly what they were before.
+        expect(root.style.overflow).toBe(overflowBefore);
+        expect(root.style.paddingRight).toBe(paddingBefore);
+    });
+
+    it('emits a cancelable dialog-request-close and closes on the close button', async () => {
+        const el = await dialogFixture();
+        await el.show();
+
+        let source;
+        el.addEventListener('dialog-request-close', (event) => {
+            source = event.detail.source;
+        });
+
+        const closed = oneEvent(el, 'dialog-after-hide');
+        el.shadowRoot.querySelector('[data-dialog-close]').click();
+        await closed;
+
+        expect(source).toBe('close-button');
+        expect(el.open).toBe(false);
+    });
+
+    it('routes the native cancel (Escape) through a cancelable close', async () => {
+        const el = await dialogFixture();
+        await el.show();
+        const dialog = el.shadowRoot.querySelector('dialog');
+
+        const closed = oneEvent(el, 'dialog-after-hide');
+        dialog.dispatchEvent(new Event('cancel', { cancelable: true }));
+        await closed;
+
+        expect(el.open).toBe(false);
+    });
+
+    it('stays open when dialog-request-close is prevented', async () => {
+        const el = await dialogFixture();
+        await el.show();
+        el.addEventListener('dialog-request-close', (event) => event.preventDefault());
+
+        el.requestClose('keyboard');
+        await nextFrame();
+
+        expect(el.open).toBe(true);
+    });
+
+    it('treats a click outside the panel as an overlay close', async () => {
+        const el = await dialogFixture();
+        await el.show();
+        const dialog = el.shadowRoot.querySelector('dialog');
+
+        const closed = oneEvent(el, 'dialog-after-hide');
+        // Target the dialog itself at the top-left corner, well outside the centered panel box.
+        dialog.dispatchEvent(new MouseEvent('click', { bubbles: true, clientX: 0, clientY: 0 }));
+        await closed;
+
+        expect(el.open).toBe(false);
+    });
+
+    it('omits the header and close button with no-header', async () => {
+        const el = await dialogFixture('no-header="true"');
+        await nextFrame();
+        expect(el.shadowRoot.querySelector('[part="header"]')).toBeNull();
+        expect(el.shadowRoot.querySelector('[data-dialog-close]')).toBeNull();
+        // The accessible name falls back to the label.
+        expect(el.shadowRoot.querySelector('dialog').getAttribute('aria-label')).toBe('Dialog title');
+    });
+
+    it('collapses the footer when nothing is slotted into it', async () => {
+        const withFooter = await dialogFixture();
+        await nextFrame();
+        expect(withFooter.shadowRoot.querySelector('[part="footer"]').classList.contains('is-empty')).toBe(false);
+
+        const withoutFooter = await fixture(`<el-dialog label="Title"><p>Body only.</p></el-dialog>`);
+        await nextFrame();
+        expect(withoutFooter.shadowRoot.querySelector('[part="footer"]').classList.contains('is-empty')).toBe(true);
+    });
+
+    it('has no detectable a11y violations while open', async () => {
+        const el = await dialogFixture();
+        await el.show();
+        const results = await axe.run(el);
+        expect(results.violations.map((violation) => violation.id)).toEqual([]);
+        await el.hide();
+    });
+});

--- a/src/components/dialog/dialog.test.unit.js
+++ b/src/components/dialog/dialog.test.unit.js
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import Dialog, { define } from './dialog.js';
+import Events from './dialog.events.js';
+define();
+
+describe('Unit | Dialog', () => {
+    it('can be created without errors', async () => {
+        const el = new Dialog();
+        expect(el).toBeInstanceOf(Dialog);
+    });
+
+    it('exposes the event-name constants', async () => {
+        expect(Events.REQUEST_CLOSE).toBe('dialog-request-close');
+        expect(Events.AFTER_SHOW).toBe('dialog-after-show');
+        expect(Events.AFTER_HIDE).toBe('dialog-after-hide');
+    });
+});

--- a/src/docs/demo.stories.js
+++ b/src/docs/demo.stories.js
@@ -14,9 +14,10 @@ export default {
                 component:
                     'A single, somewhat realistic page — a design system built with the library itself — that wires up ' +
                     'every component in the library the way they tend to be used together: a sticky header with a ' +
-                    'dropdown resources menu, a hero carousel of palette swatches, token tabs, a token-catalogue ' +
-                    'slider, a lazy-loaded pattern gallery, a request-access form built from the field components, an ' +
-                    'FAQ accordion, and the transition + scroll helpers. The design-system framing leans into the ' +
+                    'dropdown resources menu, a hero carousel of palette swatches with a walkthrough dialog, token ' +
+                    'tabs, a token-catalogue slider, a lazy-loaded pattern gallery, a request-access form built from ' +
+                    'the field components, an FAQ accordion, and the transition + scroll helpers. The design-system ' +
+                    'framing leans into the ' +
                     'theming story — flip the **Theme** and **Color scheme** toolbar switches to see the whole page ' +
                     're-skin through the design tokens.',
             },
@@ -217,9 +218,47 @@ export const Page = {
                         A token-driven design system implemented as real web components with
                         <code>@webtides/element-library</code>. Theme it once, ship it everywhere.
                     </p>
-                    <el-scroll-to selector="#start">
-                        <el-button variant="primary" size="large">Get the kit</el-button>
-                    </el-scroll-to>
+                    <div class="flex items-center justify-center gap-3 flex-wrap">
+                        <el-scroll-to selector="#start">
+                            <el-button variant="primary" size="large">Get the kit</el-button>
+                        </el-scroll-to>
+
+                        <!-- A modal built from the library itself: form-field + buttons inside el-dialog.
+                             The trigger opens its adjacent dialog; the scrim + panel re-skin with the theme. -->
+                        <span class="inline-block">
+                            <el-button
+                                variant="default"
+                                size="large"
+                                outline="true"
+                                onclick="this.nextElementSibling.show()"
+                            >
+                                Book a walkthrough
+                            </el-button>
+                            <el-dialog label="Book a walkthrough">
+                                <p class="opacity-80 mb-4">
+                                    Pick a time and we'll walk your team through the tokens, components and theming
+                                    workflow.
+                                </p>
+                                <el-input-field
+                                    name="when"
+                                    type="text"
+                                    label="Preferred date"
+                                    placeholder="Next Tuesday, 2pm"
+                                ></el-input-field>
+                                <el-button
+                                    slot="footer"
+                                    variant="default"
+                                    outline="true"
+                                    onclick="this.closest('el-dialog').hide()"
+                                >
+                                    Maybe later
+                                </el-button>
+                                <el-button slot="footer" variant="primary" onclick="this.closest('el-dialog').hide()">
+                                    Confirm
+                                </el-button>
+                            </el-dialog>
+                        </span>
+                    </div>
 
                     <div class="mt-10 rounded-xl overflow-hidden">
                         <el-carousel>

--- a/src/docs/theming.mdx
+++ b/src/docs/theming.mdx
@@ -126,7 +126,7 @@ All tokens use the `--el-` prefix. Component CSS reads them with null-ish fallba
 | `--el-shadow-md` | `0 4px 12px light-dark(…)`  | `none`              |
 | `--el-shadow-lg` | `0 12px 24px light-dark(…)` | `none`              |
 
-`--el-shadow-lg` is used by floating surfaces (currently `el-dropdown-element`'s panel; future popovers/modals). `--el-shadow-md` is part of the contract for inline elevation but isn't read by any current component — set it in your theme to ready it for future surfaces or your own overrides.
+`--el-shadow-lg` is used by floating surfaces (`el-dropdown`'s panel and `el-dialog`'s panel; future popovers). `--el-shadow-md` is part of the contract for inline elevation but isn't read by any current component — set it in your theme to ready it for future surfaces or your own overrides.
 
 ### Motion
 
@@ -143,6 +143,18 @@ All tokens use the `--el-` prefix. Component CSS reads them with null-ish fallba
 | `--el-focus-ring-offset` | `2px`         | `2px`               |
 | `--el-control-height`    | `2.5rem`      | `2.75rem`           |
 | `--el-touch-target`      | `2.75rem`     | `3rem`              |
+
+### Component tokens
+
+A few components add their own tokens on top of the shared vocabulary above. They have null-ish or sensible fallbacks, so they're optional — set them in a theme to tune that component.
+
+| Token                            | Default theme                        | Fallback (headless) | Used by                                        |
+| -------------------------------- | ------------------------------------ | ------------------- | ---------------------------------------------- |
+| `--el-dialog-width`              | `31rem`                              | `31rem`             | `el-dialog` panel width.                       |
+| `--el-dialog-overlay-background` | `rgba(17, 24, 39, 0.5)` (dark scrim) | `transparent`       | `el-dialog` `::backdrop` (the overlay scrim).  |
+| `--el-dialog-enter-offset`       | _(unset)_                            | `0.5rem`            | Vertical distance the dialog animates in from. |
+
+Because the overlay scrim falls back to `transparent`, an **unthemed** `el-dialog` has no visible backdrop — it stays headless like every other component. Import a theme (or set `--el-dialog-overlay-background` yourself) to get the dimmed background.
 
 ## Writing your own theme
 

--- a/src/themes/default.css
+++ b/src/themes/default.css
@@ -67,6 +67,10 @@
   /* Sizing */
   --el-control-height: 2.5rem;
   --el-touch-target: 2.75rem;
+
+  /* Dialog — overlay scrim dims the inert background; the panel reads the shared surface tokens */
+  --el-dialog-width: 31rem;
+  --el-dialog-overlay-background: light-dark(rgba(17, 24, 39, 0.5), rgba(0, 0, 0, 0.6));
 }
 
 /*

--- a/src/themes/high-contrast.css
+++ b/src/themes/high-contrast.css
@@ -64,6 +64,10 @@
   /* Sizing — bumped touch target to comfortably exceed WCAG 2.1 (44px) */
   --el-control-height: 2.75rem;
   --el-touch-target: 3rem;
+
+  /* Dialog — a heavier scrim for an unambiguous separation from the background */
+  --el-dialog-width: 31rem;
+  --el-dialog-overlay-background: light-dark(rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.85));
 }
 
 /*

--- a/src/themes/sketchy.css
+++ b/src/themes/sketchy.css
@@ -102,6 +102,10 @@
   /* Sizing */
   --el-control-height: 2.5rem;
   --el-touch-target: 2.75rem;
+
+  /* Dialog — an ink-wash scrim in the page's ink color */
+  --el-dialog-width: 31rem;
+  --el-dialog-overlay-background: light-dark(rgba(43, 43, 43, 0.45), rgba(0, 0, 0, 0.6));
 }
 
 /*

--- a/src/utils/body-scroll.js
+++ b/src/utils/body-scroll.js
@@ -1,0 +1,43 @@
+/**
+ * Ref-counted body-scroll lock. The first caller to lock takes the lock (hiding overflow on the
+ * document element); it is only released once every caller has unlocked. This lets stacked overlays
+ * (e.g. multiple open dialogs) cooperate without one closing dialog re-enabling scrolling for
+ * another that is still open.
+ *
+ * Hiding the root overflow removes the scrollbar, which would otherwise widen the page content and
+ * cause a visible layout shift. To prevent that, the lock pads the document element by the width of
+ * the scrollbar it just removed (a no-op on overlay-scrollbar systems, where the width is 0).
+ */
+
+let scrollLockCount = 0;
+let previousRootOverflow = '';
+let previousRootPaddingRight = '';
+
+/** Locks scrolling on the document element, compensating for the removed scrollbar width. */
+export function lockBodyScroll() {
+    if (scrollLockCount === 0) {
+        const root = document.documentElement;
+        // Measure the scrollbar before hiding it: viewport width minus the content (client) width.
+        const scrollbarWidth = window.innerWidth - root.clientWidth;
+
+        previousRootOverflow = root.style.overflow;
+        previousRootPaddingRight = root.style.paddingRight;
+
+        root.style.overflow = 'hidden';
+        if (scrollbarWidth > 0) {
+            const currentPaddingRight = parseFloat(getComputedStyle(root).paddingRight) || 0;
+            root.style.paddingRight = `${currentPaddingRight + scrollbarWidth}px`;
+        }
+    }
+    scrollLockCount += 1;
+}
+
+/** Releases one lock; restores the original overflow and padding once the last lock is released. */
+export function unlockBodyScroll() {
+    scrollLockCount = Math.max(0, scrollLockCount - 1);
+    if (scrollLockCount === 0) {
+        const root = document.documentElement;
+        root.style.overflow = previousRootOverflow;
+        root.style.paddingRight = previousRootPaddingRight;
+    }
+}

--- a/src/utils/transitions.js
+++ b/src/utils/transitions.js
@@ -1,0 +1,39 @@
+/** Largest comma-separated time (in seconds) from a computed transition value, e.g. "0.2s, 0.3s". */
+function maxSeconds(value) {
+    return Math.max(0, ...value.split(',').map((part) => parseFloat(part) || 0));
+}
+
+/**
+ * Resolves once `element`'s running CSS transition finishes — or immediately when none is set
+ * (e.g. an unthemed component, or `prefers-reduced-motion` collapsing the duration to `0s`).
+ * @param {Element} element
+ * @returns {Promise<void>}
+ */
+export function afterTransition(element) {
+    return new Promise((resolve) => {
+        const styles = getComputedStyle(element);
+        const duration = maxSeconds(styles.transitionDuration) + maxSeconds(styles.transitionDelay);
+        if (duration === 0) {
+            resolve();
+            return;
+        }
+        let settled = false;
+        const finish = () => {
+            if (settled) return;
+            settled = true;
+            element.removeEventListener('transitionend', onEnd);
+            resolve();
+        };
+        const onEnd = (event) => {
+            if (event.target === element) finish();
+        };
+        element.addEventListener('transitionend', onEnd);
+        // Safety net in case `transitionend` never fires (interrupted transition, hidden tab, …).
+        setTimeout(finish, duration * 1000 + 50);
+    });
+}
+
+/** Resolves after two animation frames — long enough for an enter starting-style to be committed. */
+export function nextFrame() {
+    return new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve())));
+}


### PR DESCRIPTION
## Summary

Adds an **`el-dialog`** component — a modal dialog modelled on Shoelace's `<sl-dialog>`, built on the native `<dialog>` element so the platform provides focus trapping, background `inert`, top-layer rendering, focus restoration and `<form method="dialog">` auto-close. On top of that it adds:

- an animated, **cancelable** open/close lifecycle (`show()` / `hide()` return promises that resolve after the transition);
- the cancelable **`dialog-request-close`** event with `detail.source: 'close-button' | 'keyboard' | 'overlay'`;
- **ref-counted body-scroll locking** that compensates for the removed scrollbar width, so opening the dialog causes **no layout shift** (no-op on overlay-scrollbar systems).

### API surface
- **Props:** `open` (reflected), `label`, `no-header` (reflected), `close-label`
- **Methods:** `show()`, `hide()`, `requestClose(source)`
- **Events:** `dialog-show` / `-after-show` / `-hide` / `-after-hide`, cancelable `dialog-initial-focus`, cancelable `dialog-request-close`
- **Slots:** default (body), `label`, `header-actions`, `footer` (collapses when empty)
- **Parts:** `base` (the `<dialog>`/panel; overlay is its `::backdrop`), `header`, `title`, `header-actions`, `close-button`, `body`, `footer`
- **State:** `:host(:state(open))`; **tokens:** `--el-dialog-width`, `--el-dialog-overlay-background`, `--el-dialog-enter-offset`

### Also in this PR
- Extracted shared helpers into **`src/utils/`** (`body-scroll.js`, `transitions.js`).
- Wired the `--el-dialog-*` tokens (width + overlay scrim) into **all three themes** (default / high-contrast / sketchy).
- Documented the dialog tokens and a `scrollbar-gutter: stable` note (theming page + component readme).
- Added the dialog to the **Demo / Example Page** (hero "Book a walkthrough" modal composed from `el-input-field` + `el-button`).
- README components table updated; removed `dialog-element` from the planned list.
- Ignore transient `.vitest-attachments/` debug output.

## Testing
- Full unit + feature coverage, including **axe-core** a11y on the open dialog, the cancelable close paths (close button / Escape `cancel` / overlay click), `no-header`, empty-footer collapse, and **scroll-lock restore**.
- Stories run as tests via the Vitest addon (default / no-header / scrolling / prevent-close).
- `npm test` green across the suite; ESLint + Prettier clean.

> Pre-1.0: this is a new component (additive), no breaking changes.