### PR TITLE
feat(radio-field): add el-radio-field single-choice group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/) and this 
 ### Components
 
 - Added: new `el-button` component — a themeable button modelled on Shoelace's `<sl-button>` (variants, sizes, outline/pill/circle, caret, loading, prefix/suffix slots, link mode).
+- Added: new `el-radio-field` component — a single-choice radio group extending `FormField`, rendering a native `<fieldset>`/`<legend>` of mutually-exclusive radios from an `options` array (strings or `{ value, label?, disabled? }`) with a custom, headless-by-default indicator. Inherits the `input-change` event and `touched`/`valid`/`invalid` states.
 - Changed (BREAKING): dropped the `-element` suffix from five components. The tags `el-accordion-element / el-carousel-element / el-dropdown-element / el-slider-element / el-sticky-element` are now `el-accordion / el-carousel / el-dropdown / el-slider / el-sticky`; their import subpaths (`@webtides/element-library/<name>` and `/<name>/define`) and exported classes (`AccordionElement → Accordion`, `CarouselElement → Carousel`, `DropdownElement → Dropdown`, `SliderElement → Slider`, `StickyElement → Sticky`) change to match. `accordion-group` is unchanged.
 
 ### Theming

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Each theme defines the library's `--el-*` design-token contract at `:root` and u
 | form-field         |                                                                               | `0.1.0` |
 | input-field        |                                                                               | `0.1.0` |
 | lazy-src           |                                                                               | `0.2.0` |
+| radio-field        | A single-choice radio group built on a native fieldset                        | `0.1.0` |
 | scroll-to          |                                                                               | `0.1.0` |
 | scroll-to-top      |                                                                               | `0.1.0` |
 | select-field       |                                                                               | `0.1.0` |
@@ -105,7 +106,6 @@ Each theme defines the library's `--el-*` design-token contract at `:root` and u
 | text-highlight     |               | TBD |
 | tooltip-element    | Popover ?!    | TBD |
 | password-field     |             | TBD  |
-| radio-field        |             | TBD  |
 | switch-field       |             | TBD  |
 | dropdown-field     |             | TBD  |
 | range-field        |             | TBD  |

--- a/all.js
+++ b/all.js
@@ -8,6 +8,7 @@ import './src/components/dropdown/dropdown.define.js';
 import './src/components/form-field/form-field.define.js';
 import './src/components/input-field/input-field.define.js';
 import './src/components/lazy-src/lazy-src.define.js';
+import './src/components/radio-field/radio-field.define.js';
 import './src/components/scroll-to/scroll-to.define.js';
 import './src/components/scroll-to-top/scroll-to-top.define.js';
 import './src/components/select-field/select-field.define.js';

--- a/src/components/form-field/form-field.style.js
+++ b/src/components/form-field/form-field.style.js
@@ -6,7 +6,8 @@ export default css`
     el-textarea-field,
     el-select-field,
     el-amount-field,
-    el-checkbox-field {
+    el-checkbox-field,
+    el-radio-field {
         display: block;
 
         > label {

--- a/src/components/radio-field/radio-field.changelog.md
+++ b/src/components/radio-field/radio-field.changelog.md
@@ -1,0 +1,19 @@
+# Change Log
+
+All notable changes to this component live here. Versions refer to the parent `@webtides/element-library` release (see root [`CHANGELOG.md`](../../../CHANGELOG.md)); components no longer version independently.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/).
+
+<!--
+   When your PR touches this component, add an entry under Unreleased and
+   mirror it (prefixed with the component name) in root CHANGELOG.md.
+   Uncomment headings as needed.
+-->
+
+## Unreleased
+
+### Added
+
+- Initial release of `el-radio-field` — a single-choice radio group extending `FormField`. Renders a native `<fieldset>`/`<legend>` wrapping mutually-exclusive `<input type="radio">`s (native grouping, arrow-key navigation and form submission) with a custom, headless-by-default circular indicator.
+- `options` property accepting plain strings or `{ value, label?, disabled? }` objects (mirrors `el-select-field`); `value` reflects the selected option.
+- Inherits the `input-change` event and `touched` / `valid` / `invalid` custom states from `FormField`.

--- a/src/components/radio-field/radio-field.define.js
+++ b/src/components/radio-field/radio-field.define.js
@@ -1,0 +1,3 @@
+import { define } from './radio-field.js';
+
+define();

--- a/src/components/radio-field/radio-field.js
+++ b/src/components/radio-field/radio-field.js
@@ -1,0 +1,140 @@
+import { html, defineElement } from '@webtides/element-js';
+import FormField from '../form-field/form-field.js';
+import style from './radio-field.style.js';
+
+/**
+ * A single-choice radio group with a custom indicator, label, help text and validation. Renders a
+ * native `<fieldset>`/`<legend>` wrapping mutually-exclusive `<input type="radio">`s (so keyboard
+ * navigation, grouping and form submission are all native). Extends `FormField` and inherits its
+ * help / error / required / touched-state surface; the `label` becomes the group's `<legend>`.
+ *
+ * @element el-radio-field
+ *
+ * @fires {CustomEvent<string>} input-change - Fired when the selected value changes. `detail` is
+ *   the newly selected value. Bubbles.
+ *
+ * @cssstate touched - Set once the user has focused and blurred the group. Inherits `valid` and
+ *   `invalid` from `FormField`.
+ *
+ * @property {string} value - The selected option's value.
+ * @property {Array<string | { value: string, label?: string, disabled?: boolean }>} options -
+ *   Options to render. Accepts plain strings (`['Yes', 'No']`) or option objects
+ *   (`[{ value, label, disabled? }]`). Strings are used as both value and label.
+ */
+export default class RadioField extends FormField {
+    /** @private */
+    uuid = Math.random().toString(36).substr(2, 5);
+
+    constructor(options) {
+        super({ shadowRender: false, styles: [style], ...options });
+    }
+
+    properties() {
+        return {
+            ...super.properties(),
+            options: [],
+        };
+    }
+
+    connected() {
+        super.connected();
+        // Reflect validity (required-but-empty) so :state(invalid) is correct from the start; the
+        // message stays hidden until the group is touched.
+        this.valid = this._computeValid();
+    }
+
+    events() {
+        return {
+            'input[type="radio"]': {
+                change: (event) => {
+                    this.value = event.target.value;
+                    this.valid = this._computeValid();
+                },
+                focus: () => this.onFocus(),
+                blur: () => this.onBlur(),
+            },
+        };
+    }
+
+    /**
+     * Whether the group currently passes validation. A radio group's only native constraint is
+     * `required`, so this is timing-independent (no rendered input needed): required ⇒ a value
+     * must be selected.
+     * @private
+     */
+    _computeValid() {
+        if (this.required) return this.value != null && this.value !== '';
+        return true;
+    }
+
+    onFocus() {
+        this.valid = this._computeValid();
+    }
+
+    onBlur() {
+        this.touched = true;
+        this.valid = this._computeValid();
+    }
+
+    /**
+     * The label is rendered as the group's `<legend>` (see `template`), so the base FormField
+     * `<label>` is suppressed.
+     * @returns {null}
+     */
+    labelTemplate() {
+        return null;
+    }
+
+    template() {
+        return html`
+            <fieldset
+                class="field ${this.classes().field}"
+                aria-describedby="${this.name}-help-message"
+                aria-errormessage="${this.name}-error-message"
+                aria-invalid="${this.valid ? 'false' : 'true'}"
+            >
+                ${this.legendTemplate()} ${this.helpTemplate()}
+                <div class="options">${this.fieldTemplate()}</div>
+                ${this.errorTemplate()}
+            </fieldset>
+        `;
+    }
+
+    /** @private */
+    legendTemplate() {
+        if (!this.label) return null;
+        return html` <legend class="${this.classes().label}">${this.label}</legend> `;
+    }
+
+    /** @private */
+    fieldTemplate() {
+        return this.options.map((option, index) => {
+            const value = option.value ?? option;
+            const label = option.label ?? option;
+            const optionDisabled = this.disabled || !!option.disabled;
+            const checked = this.value != null && String(this.value) === String(value);
+            const id = `radio-${this.uuid}-${index}`;
+
+            return html`
+                <label class="option" for="${id}">
+                    <input
+                        type="radio"
+                        id="${id}"
+                        name="${this.name}"
+                        value="${value}"
+                        ?checked="${checked}"
+                        ?disabled="${optionDisabled}"
+                        ?required="${this.required}"
+                        aria-describedby="${this.name}-help-message"
+                    />
+                    <span class="radio-indicator" aria-hidden="true"></span>
+                    <span class="option-label">${label}</span>
+                </label>
+            `;
+        });
+    }
+}
+
+export function define() {
+    defineElement('el-radio-field', RadioField);
+}

--- a/src/components/radio-field/radio-field.readme.md
+++ b/src/components/radio-field/radio-field.readme.md
@@ -1,0 +1,72 @@
+# RadioField
+
+`radio-field` is a single-choice radio group. It renders a native `<fieldset>`/`<legend>` wrapping mutually-exclusive `<input type="radio">`s — so grouping, arrow-key navigation and form submission are all native — with a custom indicator on top. It extends `form-field`, inheriting the label, help text, error message, `required` and touched-state handling.
+
+It is headless by default: without a theme the indicator falls back to a `currentColor` outline.
+
+## How to use
+
+#### Install
+
+```sh
+npm i --save @webtides/element-library
+```
+
+#### Use
+
+```js
+import '@webtides/element-library/radio-field/define';
+```
+
+```html
+<el-radio-field name="plan" label="Choose a plan" required="true"></el-radio-field>
+
+<script>
+    document.querySelector('el-radio-field').options = ['Starter', 'Pro', 'Enterprise'];
+</script>
+```
+
+Options may be plain strings or objects with separate `value` / `label` and an optional per-option `disabled` flag:
+
+```js
+field.options = [
+    { value: 'standard', label: 'Standard (free)' },
+    { value: 'priority', label: 'Priority' },
+    { value: 'dedicated', label: 'Dedicated (sold out)', disabled: true }
+];
+```
+
+## API
+
+#### Properties/Attributes
+
+Inherits all of `form-field`'s properties (`name`, `value`, `required`, `disabled`, `label`, `labelScreenReaderOnly`, `errorMessage`, `helpMessage`, `valid`, `touched`) and adds:
+
+| Name | Type | Default | Description |
+| --- | --- | --- | --- |
+| `value` | `string` | `null` | The selected option's value. |
+| `options` | `Array<string \| { value: string, label?: string, disabled?: boolean }>` | `[]` | Options to render. Strings are used as both value and label; objects allow a separate label/disabled. |
+
+#### Events
+
+| Name           | Detail               | Description                            |
+| -------------- | -------------------- | -------------------------------------- |
+| `input-change` | `string` (the value) | Fired when the selected value changes. |
+
+#### CSS States
+
+| Name      | Description                                                               |
+| --------- | ------------------------------------------------------------------------- |
+| `touched` | Set once the group has been focused and blurred.                          |
+| `valid`   | Set while the group passes validation.                                    |
+| `invalid` | Set while the group fails validation (e.g. `required` with no selection). |
+
+#### CSS Custom Properties
+
+Headless by default; reads the library's `--el-*` design tokens (`--el-color-accent`, `--el-color-border`, `--el-color-bg`, `--el-space-*`, `--el-border-width`, `--el-focus-ring-width`, `--el-duration-md`, `--el-ease`, `--el-color-fg-muted`, `--el-color-danger`). Skin it via a theme — see the Storybook _Docs / Theming_ page.
+
+## Accessibility
+
+- Uses a native `<fieldset>` + `<legend>`, so the group is announced with its label and radios are mutually exclusive with native arrow-key navigation.
+- The native radio stays in the accessibility tree and focusable; it is only hidden visually, with keyboard focus reflected onto the custom indicator via `:focus-visible`.
+- Validation messages surface only once the group is `touched`.

--- a/src/components/radio-field/radio-field.stories.js
+++ b/src/components/radio-field/radio-field.stories.js
@@ -1,0 +1,106 @@
+import { userEvent, within, expect, waitFor } from 'storybook/test';
+import { html } from '@webtides/element-js';
+import readme from './radio-field.readme.md?raw';
+import { define } from './radio-field.js';
+define();
+
+export default {
+    title: 'Components/RadioField',
+    component: 'el-radio-field',
+    tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component: readme,
+            },
+        },
+    },
+    args: {
+        name: 'plan',
+        label: 'Choose a plan',
+        value: '',
+        required: true,
+        disabled: false,
+        helpMessage: 'You can change this later.',
+        errorMessage: 'Please pick a plan.',
+        options: ['Starter', 'Pro', 'Enterprise'],
+    },
+};
+
+export const RadioField = {
+    parameters: {
+        docs: {
+            description: {
+                story: 'A single-choice radio group rendered from an `options` array, inheriting label, help, validation and touched-state handling from `form-field`.',
+            },
+        },
+    },
+    render: ({ name, label, value, required, disabled, helpMessage, errorMessage, options }) => html`
+        <el-radio-field
+            name="${name}"
+            label="${label}"
+            value="${value}"
+            required="${required ? 'true' : 'false'}"
+            disabled="${disabled ? 'true' : 'false'}"
+            help-message="${helpMessage}"
+            error-message="${errorMessage}"
+            .options="${options}"
+        ></el-radio-field>
+    `,
+    play: async ({ canvasElement, step }) => {
+        const canvas = within(canvasElement);
+        const field = canvasElement.querySelector('el-radio-field');
+
+        await step('renders one radio per option, none selected', async () => {
+            // el-radio-field renders its radios into light DOM asynchronously on connect, so wait
+            // for them rather than querying synchronously.
+            const radios = await canvas.findAllByRole('radio');
+            await expect(radios).toHaveLength(3);
+            await expect(field.value).toBeFalsy();
+        });
+
+        await step('selecting an option updates the value and emits input-change', async () => {
+            // input-change is dispatched from the value watcher (a microtask after the setter), so
+            // await the event rather than reading a captured variable right away.
+            const changed = new Promise((resolve) =>
+                field.addEventListener('input-change', (event) => resolve(event.detail), { once: true }),
+            );
+            await userEvent.click(await canvas.findByLabelText('Pro'));
+            await waitFor(() => expect(field.value).toBe('Pro'));
+            await expect(await changed).toBe('Pro');
+        });
+    },
+};
+
+export const WithObjectOptions = {
+    name: 'Object options (with a disabled choice)',
+    parameters: {
+        docs: {
+            description: {
+                story: 'Options can be objects with separate `value`/`label` and a per-option `disabled` flag.',
+            },
+        },
+    },
+    args: {
+        name: 'tier',
+        label: 'Support tier',
+        value: 'standard',
+        required: false,
+        helpMessage: '',
+        options: [
+            { value: 'standard', label: 'Standard (free)' },
+            { value: 'priority', label: 'Priority' },
+            { value: 'dedicated', label: 'Dedicated (sold out)', disabled: true },
+        ],
+    },
+    render: ({ name, label, value, required, helpMessage, options }) => html`
+        <el-radio-field
+            name="${name}"
+            label="${label}"
+            value="${value}"
+            required="${required ? 'true' : 'false'}"
+            help-message="${helpMessage}"
+            .options="${options}"
+        ></el-radio-field>
+    `,
+};

--- a/src/components/radio-field/radio-field.style.js
+++ b/src/components/radio-field/radio-field.style.js
@@ -1,0 +1,108 @@
+const css = String.raw;
+
+export default css`
+    el-radio-field {
+        display: block;
+
+        fieldset.field {
+            margin: 0;
+            padding: 0;
+            border: 0;
+            min-width: 0;
+        }
+
+        legend {
+            padding: 0;
+            margin-bottom: var(--el-space-1, 0);
+            color: var(--el-color-fg, inherit);
+        }
+
+        .options {
+            display: flex;
+            flex-direction: column;
+            gap: var(--el-space-2, 0.5em);
+        }
+
+        .option {
+            display: inline-flex;
+            align-items: center;
+            gap: var(--el-space-2, 0.5em);
+            cursor: pointer;
+        }
+
+        .option:has(input:disabled) {
+            cursor: not-allowed;
+        }
+
+        /* The native radio is replaced by .radio-indicator; hide it visually but keep it in the
+           accessibility tree and focusable. */
+        input[type='radio'] {
+            position: absolute;
+            width: 1px;
+            height: 1px;
+            margin: 0;
+            padding: 0;
+            border: 0;
+            opacity: 0;
+            overflow: hidden;
+            white-space: nowrap;
+            clip: rect(0 0 0 0);
+            clip-path: inset(50%);
+        }
+
+        /* Reflect keyboard focus onto the custom indicator. */
+        input[type='radio']:focus-visible + .radio-indicator {
+            outline: var(--el-focus-ring-width, 2px) solid var(--el-color-accent, currentColor);
+            outline-offset: 2px;
+        }
+
+        .radio-indicator {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            flex: none;
+            /* Fallbacks render a usable circle even without a theme, since the native input is hidden. */
+            width: var(--el-space-4, 1em);
+            height: var(--el-space-4, 1em);
+            border: var(--el-border-width, 1px) solid var(--el-color-border, currentColor);
+            border-radius: 50%;
+            background: var(--el-color-bg, transparent);
+            transition: border-color var(--el-duration-md, 0s) var(--el-ease, linear);
+        }
+
+        /* The filled dot scales in when the option is selected (driven by :checked, no host state). */
+        .radio-indicator::after {
+            content: '';
+            width: 50%;
+            height: 50%;
+            border-radius: 50%;
+            background: var(--el-color-accent, currentColor);
+            transform: scale(0);
+            transition: transform var(--el-duration-md, 0s) var(--el-ease, linear);
+        }
+
+        input[type='radio']:checked + .radio-indicator {
+            border-color: var(--el-color-accent, currentColor);
+        }
+
+        input[type='radio']:checked + .radio-indicator::after {
+            transform: scale(1);
+        }
+
+        input[type='radio']:disabled + .radio-indicator {
+            opacity: 0.5;
+        }
+
+        .message {
+            display: block;
+        }
+
+        .help-message {
+            color: var(--el-color-fg-muted, inherit);
+        }
+
+        .error-message {
+            color: var(--el-color-danger, inherit);
+        }
+    }
+`;

--- a/src/components/radio-field/radio-field.test.feature.js
+++ b/src/components/radio-field/radio-field.test.feature.js
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import axe from 'axe-core';
+import { fixture, nextFrame, oneEvent } from '../../test-helpers.js';
+import { define } from './radio-field.js';
+define();
+
+// Options are passed as a JSON attribute so they are present at connect time (the group's initial
+// validity is computed in connected()).
+const radioFixture = (attrs = '', options = ['Starter', 'Pro', 'Enterprise']) =>
+    fixture(
+        `<el-radio-field name="plan" label="Choose a plan" options='${JSON.stringify(options)}' ${attrs}></el-radio-field>`,
+    );
+
+describe('Feature | RadioField', () => {
+    it('can connect without errors', async () => {
+        const el = await fixture(`<el-radio-field></el-radio-field>`);
+        await nextFrame();
+    });
+
+    it('renders one radio per option inside a fieldset/legend', async () => {
+        const el = await radioFixture();
+        expect(el.querySelectorAll('input[type="radio"]')).toHaveLength(3);
+        expect(el.querySelector('fieldset')).not.toBeNull();
+        expect(el.querySelector('legend').textContent.trim()).toBe('Choose a plan');
+    });
+
+    it('selecting a radio updates value and emits input-change', async () => {
+        const el = await radioFixture();
+        const changed = oneEvent(el, 'input-change');
+        el.querySelectorAll('input[type="radio"]')[1].click();
+        const event = await changed;
+        expect(el.value).toBe('Pro');
+        expect(event.detail).toBe('Pro');
+    });
+
+    it('shares a name so the radios are mutually exclusive', async () => {
+        const el = await radioFixture();
+        const radios = [...el.querySelectorAll('input[type="radio"]')];
+        expect(radios.every((radio) => radio.name === 'plan')).toBe(true);
+
+        radios[0].click();
+        await nextFrame();
+        radios[2].click();
+        await nextFrame();
+
+        expect(radios.filter((radio) => radio.checked)).toHaveLength(1);
+        expect(el.value).toBe('Enterprise');
+    });
+
+    it('is invalid while required and unselected, valid once a choice is made', async () => {
+        const el = await radioFixture('required="true"');
+        // The state reflects validity immediately; the message stays hidden until touched.
+        expect(el.matches(':state(invalid)')).toBe(true);
+
+        el.querySelectorAll('input[type="radio"]')[0].click();
+        await nextFrame();
+        expect(el.matches(':state(valid)')).toBe(true);
+    });
+
+    it('disables an individual option via the option object', async () => {
+        const el = await radioFixture('', [
+            { value: 'a', label: 'A' },
+            { value: 'b', label: 'B', disabled: true },
+        ]);
+        const radios = el.querySelectorAll('input[type="radio"]');
+        expect(radios[0].disabled).toBe(false);
+        expect(radios[1].disabled).toBe(true);
+    });
+
+    it('has no detectable a11y violations', async () => {
+        const el = await radioFixture('value="Pro"');
+        await nextFrame();
+        const results = await axe.run(el);
+        expect(results.violations.map((violation) => violation.id)).toEqual([]);
+    });
+});

--- a/src/components/radio-field/radio-field.test.unit.js
+++ b/src/components/radio-field/radio-field.test.unit.js
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest';
+import RadioField, { define } from './radio-field.js';
+define();
+
+describe('Unit | RadioField', () => {
+    it('can be created without errors', async () => {
+        const el = new RadioField();
+        expect(el).toBeInstanceOf(RadioField);
+    });
+});

--- a/src/docs/demo.stories.js
+++ b/src/docs/demo.stories.js
@@ -340,6 +340,20 @@ export const Page = {
                         </div>
 
                         <div class="sm:col-span-2">
+                            <el-radio-field
+                                name="billing"
+                                label="Billing cycle"
+                                value="annual"
+                                required="true"
+                                help-message="Annual saves two months."
+                                .options="${[
+                                    { value: 'monthly', label: 'Monthly' },
+                                    { value: 'annual', label: 'Annual' },
+                                ]}"
+                            ></el-radio-field>
+                        </div>
+
+                        <div class="sm:col-span-2">
                             <el-textarea-field
                                 name="context"
                                 label="What are you building?"


### PR DESCRIPTION
## Summary

Adds **`el-radio-field`** — a single-choice radio group that extends `FormField` (light DOM). It renders a native `<fieldset>`/`<legend>` wrapping mutually-exclusive `<input type="radio">`s from an `options` array, so grouping, arrow-key navigation and form submission are all native. A custom, headless-by-default circular indicator sits on top.

### API
- **`options`** — `Array<string | { value, label?, disabled? }>` (mirrors `el-select-field`); strings are used as both value and label.
- **`value`** — reflects the selected option.
- Inherits `name`, `required`, `disabled`, `label`, `helpMessage`, `errorMessage`, `valid`, `touched` from `FormField`, plus the **`input-change`** event and **`touched` / `valid` / `invalid`** custom states.

### Notes
- Headless by default — the indicator falls back to a `currentColor` outline; reads the shared `--el-*` tokens otherwise. Added `el-radio-field` to the shared `form-field` stylesheet selector list.
- Initial validity is computed logically (`required` ⇒ a value must be selected) rather than from rendered inputs, which aren't reliably present at `connected()` time.
- Demonstrated in the **Demo / Example Page** request-access form (a "Billing cycle" group, using element-js's `.options` property binding).
- README components table updated; removed from the planned list.

## Testing
- Unit + feature coverage: renders one radio per option in a `fieldset`/`legend`, mutual exclusion via shared `name`, `input-change` on selection, `required` validity transitions, per-option `disabled`, and **axe-core** a11y.
- Stories run as tests via the Vitest addon (a play function selects an option and asserts value + event).
- `npm test` green; ESLint + Prettier clean.

> Pre-1.0: new component, additive, no breaking changes. Branched off `main` (independent of the `el-dialog` PR #51).