### PR TITLE
feat(switch-field): add el-switch-field on/off toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/) and this 
 
 - Added: new `el-button` component — a themeable button modelled on Shoelace's `<sl-button>` (variants, sizes, outline/pill/circle, caret, loading, prefix/suffix slots, link mode).
 - Added: new `el-radio-field` component — a single-choice radio group extending `FormField`, rendering a native `<fieldset>`/`<legend>` of mutually-exclusive radios from an `options` array (strings or `{ value, label?, disabled? }`) with a custom, headless-by-default indicator. Inherits the `input-change` event and `touched`/`valid`/`invalid` states.
+- Added: new `el-switch-field` component — an on/off toggle extending `FormField`, rendering a native `<input type="checkbox">` with `role="switch"` behind a custom, headless-by-default track/thumb. Reflects `checked`, adds a `checked` custom state, and inherits the `input-change` event and `touched`/`valid`/`invalid` states.
 - Changed (BREAKING): dropped the `-element` suffix from five components. The tags `el-accordion-element / el-carousel-element / el-dropdown-element / el-slider-element / el-sticky-element` are now `el-accordion / el-carousel / el-dropdown / el-slider / el-sticky`; their import subpaths (`@webtides/element-library/<name>` and `/<name>/define`) and exported classes (`AccordionElement → Accordion`, `CarouselElement → Carousel`, `DropdownElement → Dropdown`, `SliderElement → Slider`, `StickyElement → Sticky`) change to match. `accordion-group` is unchanged.
 
 ### Theming

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Each theme defines the library's `--el-*` design-token contract at `:root` and u
 | slider             | CSS only slider element to slide child elements                               | `0.4.3` |
 | sticky             |                                                                               | `0.2.0` |
 | svg-use            |                                                                               | `0.1.0` |
+| switch-field       | An on/off toggle backed by a native checkbox with role="switch"               | `0.1.0` |
 | tab-group          | A tab group wraps a list of tab-links and tab-panels and shows one at a time  | `0.1.0` |
 | tab-link           | A link that serves as a label for one of the tab panels to display that panel | `0.1.0` |
 | tab-panel          | The element that contains the content associated with a tab                   | `0.1.0` |
@@ -106,7 +107,6 @@ Each theme defines the library's `--el-*` design-token contract at `:root` and u
 | text-highlight     |               | TBD |
 | tooltip-element    | Popover ?!    | TBD |
 | password-field     |             | TBD  |
-| switch-field       |             | TBD  |
 | dropdown-field     |             | TBD  |
 | range-field        |             | TBD  |
 | input-group        |             | TBD  |

--- a/all.js
+++ b/all.js
@@ -15,6 +15,7 @@ import './src/components/select-field/select-field.define.js';
 import './src/components/slider/slider.define.js';
 import './src/components/sticky/sticky.define.js';
 import './src/components/svg-use/svg-use.define.js';
+import './src/components/switch-field/switch-field.define.js';
 import './src/components/tab-group/tab-group.define.js';
 import './src/components/tab-link/tab-link.define.js';
 import './src/components/tab-panel/tab-panel.define.js';

--- a/src/components/form-field/form-field.style.js
+++ b/src/components/form-field/form-field.style.js
@@ -7,7 +7,8 @@ export default css`
     el-select-field,
     el-amount-field,
     el-checkbox-field,
-    el-radio-field {
+    el-radio-field,
+    el-switch-field {
         display: block;
 
         > label {

--- a/src/components/switch-field/switch-field.changelog.md
+++ b/src/components/switch-field/switch-field.changelog.md
@@ -1,0 +1,19 @@
+# Change Log
+
+All notable changes to this component live here. Versions refer to the parent `@webtides/element-library` release (see root [`CHANGELOG.md`](../../../CHANGELOG.md)); components no longer version independently.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/).
+
+<!--
+   When your PR touches this component, add an entry under Unreleased and
+   mirror it (prefixed with the component name) in root CHANGELOG.md.
+   Uncomment headings as needed.
+-->
+
+## Unreleased
+
+### Added
+
+- Initial release of `el-switch-field` — an on/off toggle extending `FormField`. Renders a native `<input type="checkbox">` with `role="switch"` (announced as a switch, submits with forms) behind a custom, headless-by-default track/thumb.
+- `checked` property reflected to the `checked` attribute, plus a `checked` custom state on the host.
+- Inherits the `input-change` event and `touched` / `valid` / `invalid` states from `FormField`.

--- a/src/components/switch-field/switch-field.define.js
+++ b/src/components/switch-field/switch-field.define.js
@@ -1,0 +1,3 @@
+import { define } from './switch-field.js';
+
+define();

--- a/src/components/switch-field/switch-field.js
+++ b/src/components/switch-field/switch-field.js
@@ -1,0 +1,99 @@
+import { html, defineElement, classMap, unsafeHTML } from '@webtides/element-js';
+import FormField, { FormFieldEvents } from '../form-field/form-field.js';
+import style from './switch-field.style.js';
+
+/**
+ * An on/off toggle switch. Renders a native `<input type="checkbox">` with `role="switch"` (so it
+ * is announced as a switch and submits with forms) behind a custom track/thumb. Extends
+ * `FormField` and inherits its label / help / error / required surface.
+ *
+ * @element el-switch-field
+ *
+ * @fires {CustomEvent<string>} input-change - Fired when the on/off state changes. `detail` is the
+ *   input's `value`. Bubbles.
+ *
+ * @cssstate checked - Set on the host while the switch is on. Style with
+ *   `el-switch-field:state(checked) { … }`. Inherits `touched`, `valid` and `invalid` from
+ *   `FormField`.
+ *
+ * @property {boolean} checked - Whether the switch is on. Reflected to the `checked` attribute.
+ */
+export default class SwitchField extends FormField {
+    /** @private */
+    uuid = Math.random().toString(36).substr(2, 5);
+
+    constructor(options) {
+        super({ shadowRender: false, styles: [style], ...options });
+    }
+
+    properties() {
+        return {
+            ...super.properties(),
+            checked: false,
+        };
+    }
+
+    connected() {
+        this.setAttribute('checked', this.checked === true ? 'true' : 'false');
+        if (this.checked) this._internals.states.add('checked');
+        this.syncValidationStates();
+    }
+
+    watch() {
+        return {
+            ...super.watch(),
+            checked: (checked) => {
+                this.setAttribute('checked', checked ? 'true' : 'false');
+                if (checked) this._internals.states.add('checked');
+                else this._internals.states.delete('checked');
+                this.dispatch(FormFieldEvents.INPUT_CHANGE, this.$refs.input.value);
+            },
+        };
+    }
+
+    events() {
+        return {
+            ...super.events(),
+            input: {
+                change: () => {
+                    this.checked = this.$refs.input.checked;
+                },
+            },
+        };
+    }
+
+    /**
+     * The switch renders its label inline next to the track (see `fieldTemplate`), so the base
+     * FormField label is suppressed.
+     * @returns {null}
+     */
+    labelTemplate() {
+        return null;
+    }
+
+    fieldTemplate() {
+        const classes = { 'is-checked': !!this.checked };
+        return html`
+            <label for="switch-${this.uuid}">
+                <input
+                    ref="input"
+                    type="checkbox"
+                    role="switch"
+                    id="switch-${this.uuid}"
+                    aria-describedby="${this.name}-help-message"
+                    value="${this.value}"
+                    name="${this.name}"
+                    ?disabled="${this.disabled}"
+                    ?checked="${this.checked}"
+                    ?required="${this.required}"
+                />
+                <span class="switch-track ${classMap(classes)}"><span class="switch-thumb"></span></span>
+                <span class="label">${this.label ? unsafeHTML(this.label) : ''}</span>
+            </label>
+        `;
+    }
+}
+
+export function define() {
+    defineElement('el-switch-field', SwitchField);
+}

--- a/src/components/switch-field/switch-field.readme.md
+++ b/src/components/switch-field/switch-field.readme.md
@@ -1,0 +1,58 @@
+# SwitchField
+
+`switch-field` is an on/off toggle. It renders a native `<input type="checkbox">` with `role="switch"` — so it is announced as a switch and submits with forms — behind a custom track/thumb. It extends `form-field`, inheriting the label, help text, error message, `required` and touched-state handling.
+
+It is headless by default: without a theme the track falls back to a `currentColor` outline with a `currentColor` thumb.
+
+## How to use
+
+#### Install
+
+```sh
+npm i --save @webtides/element-library
+```
+
+#### Use
+
+```js
+import '@webtides/element-library/switch-field/define';
+```
+
+```html
+<el-switch-field name="notifications" label="Enable notifications"></el-switch-field>
+<el-switch-field name="darkmode" label="Dark mode" checked="true"></el-switch-field>
+```
+
+## API
+
+#### Properties/Attributes
+
+Inherits all of `form-field`'s properties (`name`, `value`, `required`, `disabled`, `label`, `labelScreenReaderOnly`, `errorMessage`, `helpMessage`, `valid`, `touched`) and adds:
+
+| Name      | Type      | Default | Description                                                     |
+| --------- | --------- | ------- | --------------------------------------------------------------- |
+| `checked` | `boolean` | `false` | Whether the switch is on. Reflected to the `checked` attribute. |
+
+#### Events
+
+| Name           | Detail               | Description                          |
+| -------------- | -------------------- | ------------------------------------ |
+| `input-change` | `string` (the value) | Fired when the on/off state changes. |
+
+#### CSS States
+
+| Name      | Description                                                                              |
+| --------- | ---------------------------------------------------------------------------------------- |
+| `checked` | Present on the host while the switch is on. Style with `el-switch-field:state(checked)`. |
+| `touched` | Set once the switch has been focused and blurred.                                        |
+| `valid`   | Set while the field passes validation.                                                   |
+| `invalid` | Set while the field fails validation.                                                    |
+
+#### CSS Custom Properties
+
+Headless by default; reads the library's `--el-*` design tokens (`--el-color-accent`, `--el-color-border`, `--el-color-bg`, `--el-space-2`, `--el-border-width`, `--el-focus-ring-width`, `--el-duration-md`, `--el-ease`, `--el-color-fg-muted`, `--el-color-danger`). Skin it via a theme — see the Storybook _Docs / Theming_ page.
+
+## Accessibility
+
+- The native control is a `<input type="checkbox" role="switch">`, so it is announced as a switch with an on/off state and is keyboard-operable (Space toggles).
+- The native input stays in the accessibility tree and focusable; it is only hidden visually, with keyboard focus reflected onto the custom track via `:focus-visible`.

--- a/src/components/switch-field/switch-field.stories.js
+++ b/src/components/switch-field/switch-field.stories.js
@@ -1,0 +1,92 @@
+import { userEvent, within, expect, waitFor } from 'storybook/test';
+import { html } from '@webtides/element-js';
+import readme from './switch-field.readme.md?raw';
+import { define } from './switch-field.js';
+define();
+
+export default {
+    title: 'Components/SwitchField',
+    component: 'el-switch-field',
+    tags: ['autodocs'],
+    parameters: {
+        docs: {
+            description: {
+                component: readme,
+            },
+        },
+    },
+    args: {
+        name: 'notifications',
+        label: 'Enable notifications',
+        checked: false,
+        disabled: false,
+    },
+};
+
+export const SwitchField = {
+    parameters: {
+        docs: {
+            description: {
+                story: 'An on/off toggle backed by a native `<input type="checkbox" role="switch">`, inheriting label, validation and state handling from `form-field`.',
+            },
+        },
+    },
+    render: ({ name, label, checked, disabled }) => html`
+        <el-switch-field
+            name="${name}"
+            label="${label}"
+            checked="${checked ? 'true' : 'false'}"
+            disabled="${disabled ? 'true' : 'false'}"
+        ></el-switch-field>
+    `,
+    play: async ({ canvasElement, step }) => {
+        const canvas = within(canvasElement);
+        const field = canvasElement.querySelector('el-switch-field');
+        // el-switch-field renders into light DOM asynchronously on connect, so wait for the control.
+        const control = await canvas.findByRole('switch');
+
+        await step('starts off', async () => {
+            await expect(control).not.toBeChecked();
+            await expect(field.checked).toBe(false);
+        });
+
+        await step('toggling it on updates checked and emits input-change', async () => {
+            const changed = new Promise((resolve) =>
+                field.addEventListener('input-change', () => resolve(true), { once: true }),
+            );
+            await userEvent.click(control);
+            await waitFor(() => expect(field.checked).toBe(true));
+            await expect(control).toBeChecked();
+            await expect(await changed).toBe(true);
+        });
+
+        await step('toggling it off again', async () => {
+            await userEvent.click(control);
+            await waitFor(() => expect(field.checked).toBe(false));
+        });
+    },
+};
+
+export const On = {
+    name: 'Checked by default',
+    parameters: {
+        docs: {
+            description: {
+                story: 'Set `checked="true"` to render the switch in its on state.',
+            },
+        },
+    },
+    args: {
+        name: 'darkmode',
+        label: 'Dark mode',
+        checked: true,
+    },
+    render: ({ name, label, checked, disabled }) => html`
+        <el-switch-field
+            name="${name}"
+            label="${label}"
+            checked="${checked ? 'true' : 'false'}"
+            disabled="${disabled ? 'true' : 'false'}"
+        ></el-switch-field>
+    `,
+};

--- a/src/components/switch-field/switch-field.style.js
+++ b/src/components/switch-field/switch-field.style.js
@@ -1,0 +1,98 @@
+const css = String.raw;
+
+export default css`
+    el-switch-field {
+        display: block;
+
+        .field > label {
+            display: inline-flex;
+            align-items: center;
+            gap: var(--el-space-2, 0.5em);
+            cursor: pointer;
+        }
+
+        .field > label:has(input:disabled) {
+            cursor: not-allowed;
+        }
+
+        /* The native checkbox is replaced by the track/thumb; hide it visually but keep it in the
+           accessibility tree and focusable. */
+        input[type='checkbox'] {
+            position: absolute;
+            width: 1px;
+            height: 1px;
+            margin: 0;
+            padding: 0;
+            border: 0;
+            opacity: 0;
+            overflow: hidden;
+            white-space: nowrap;
+            clip: rect(0 0 0 0);
+            clip-path: inset(50%);
+        }
+
+        /* Reflect keyboard focus onto the custom track. */
+        input[type='checkbox']:focus-visible + .switch-track {
+            outline: var(--el-focus-ring-width, 2px) solid var(--el-color-accent, currentColor);
+            outline-offset: 2px;
+        }
+
+        .switch-track {
+            position: relative;
+            display: inline-block;
+            flex: none;
+            box-sizing: border-box;
+            /* Track is sized in em so it scales with the surrounding font-size. */
+            width: 2.4em;
+            height: 1.4em;
+            border: var(--el-border-width, 1px) solid var(--el-color-border, currentColor);
+            border-radius: 999px;
+            background: var(--el-color-bg, transparent);
+            transition:
+                background var(--el-duration-md, 0s) var(--el-ease, linear),
+                border-color var(--el-duration-md, 0s) var(--el-ease, linear);
+        }
+
+        .switch-thumb {
+            position: absolute;
+            top: 50%;
+            left: 0.15em;
+            width: 1.1em;
+            height: 1.1em;
+            border-radius: 50%;
+            /* Visible against the headless (transparent) track via currentColor. */
+            background: var(--el-color-border, currentColor);
+            transform: translateY(-50%);
+            transition:
+                transform var(--el-duration-md, 0s) var(--el-ease, linear),
+                background var(--el-duration-md, 0s) var(--el-ease, linear);
+        }
+
+        input[type='checkbox']:checked + .switch-track {
+            background: var(--el-color-accent, currentColor);
+            border-color: var(--el-color-accent, currentColor);
+        }
+
+        /* Slide the thumb to the right edge and flip it to the surface color so it reads on the fill. */
+        input[type='checkbox']:checked + .switch-track .switch-thumb {
+            transform: translate(calc(2.4em - 1.1em - 0.3em), -50%);
+            background: var(--el-color-bg, Canvas);
+        }
+
+        input[type='checkbox']:disabled + .switch-track {
+            opacity: 0.5;
+        }
+
+        .message {
+            display: block;
+        }
+
+        .help-message {
+            color: var(--el-color-fg-muted, inherit);
+        }
+
+        .error-message {
+            color: var(--el-color-danger, inherit);
+        }
+    }
+`;

--- a/src/components/switch-field/switch-field.test.feature.js
+++ b/src/components/switch-field/switch-field.test.feature.js
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import axe from 'axe-core';
+import { fixture, nextFrame, oneEvent } from '../../test-helpers.js';
+import { define } from './switch-field.js';
+define();
+
+const switchFixture = (attrs = '') =>
+    fixture(`<el-switch-field name="notifications" label="Enable notifications" ${attrs}></el-switch-field>`);
+
+describe('Feature | SwitchField', () => {
+    it('can connect without errors', async () => {
+        const el = await fixture(`<el-switch-field></el-switch-field>`);
+        await nextFrame();
+    });
+
+    it('renders a native checkbox with role="switch"', async () => {
+        const el = await switchFixture();
+        const input = el.querySelector('input');
+        expect(input.type).toBe('checkbox');
+        expect(input.getAttribute('role')).toBe('switch');
+    });
+
+    it('defaults to off', async () => {
+        const el = await switchFixture();
+        expect(el.checked).toBe(false);
+        expect(el.querySelector('input').checked).toBe(false);
+        expect(el.matches(':state(checked)')).toBe(false);
+    });
+
+    it('toggling it on updates checked, the state and emits input-change', async () => {
+        const el = await switchFixture();
+        const changed = oneEvent(el, 'input-change');
+        el.querySelector('input').click();
+        await changed;
+        await nextFrame();
+        expect(el.checked).toBe(true);
+        expect(el.matches(':state(checked)')).toBe(true);
+    });
+
+    it('honours checked="true" declaratively', async () => {
+        const el = await switchFixture('checked="true"');
+        expect(el.checked).toBe(true);
+        expect(el.querySelector('input').checked).toBe(true);
+        expect(el.matches(':state(checked)')).toBe(true);
+    });
+
+    it('reflects the disabled state onto the native input', async () => {
+        const el = await switchFixture('disabled="true"');
+        expect(el.querySelector('input').disabled).toBe(true);
+    });
+
+    it('has no detectable a11y violations', async () => {
+        const el = await switchFixture();
+        const results = await axe.run(el);
+        expect(results.violations.map((violation) => violation.id)).toEqual([]);
+    });
+});

--- a/src/components/switch-field/switch-field.test.unit.js
+++ b/src/components/switch-field/switch-field.test.unit.js
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest';
+import SwitchField, { define } from './switch-field.js';
+define();
+
+describe('Unit | SwitchField', () => {
+    it('can be created without errors', async () => {
+        const el = new SwitchField();
+        expect(el).toBeInstanceOf(SwitchField);
+    });
+});

--- a/src/docs/demo.stories.js
+++ b/src/docs/demo.stories.js
@@ -363,6 +363,14 @@ export const Page = {
                         </div>
 
                         <div class="sm:col-span-2">
+                            <el-switch-field
+                                name="updates"
+                                checked="true"
+                                label="Email me occasional product updates"
+                            ></el-switch-field>
+                        </div>
+
+                        <div class="sm:col-span-2">
                             <el-checkbox-field
                                 name="terms"
                                 required="true"


### PR DESCRIPTION
## Summary

Adds **`el-switch-field`** — an on/off toggle that extends `FormField` (light DOM). It renders a native `<input type="checkbox">` with **`role="switch"`** behind a custom track/thumb, so it's announced as a switch, keyboard-operable (Space toggles), and submits with forms. Structure mirrors `el-checkbox-field` (hidden native input + custom indicator, inline label, `:focus-visible` reflected onto the control).

### API
- **`checked`** — boolean, reflected to the `checked` attribute; adds a **`checked`** custom state on the host.
- Inherits `name`, `value`, `required`, `disabled`, `label`, `helpMessage`, `errorMessage`, `valid`, `touched` from `FormField`, plus the **`input-change`** event and `touched` / `valid` / `invalid` states.

### Notes
- Headless by default — the track falls back to a `currentColor` outline with a `currentColor` thumb; reads the shared `--el-*` tokens otherwise. The toggle is sized in `em` so it scales with the surrounding font-size. Added `el-switch-field` to the shared `form-field` stylesheet selector list.
- Demonstrated in the **Demo / Example Page** request-access form ("Email me occasional product updates").
- README components table updated; removed from the planned list.

## Testing
- Unit + feature coverage: renders a native checkbox with `role="switch"`, defaults off, toggles `checked` + `:state(checked)` + emits `input-change`, honours declarative `checked="true"`, reflects `disabled`, and **axe-core** a11y.
- Stories run as tests via the Vitest addon (a play function toggles the switch on/off and asserts state + event).
- `npm test` green; ESLint + Prettier clean.

> Pre-1.0: new component, additive, no breaking changes. Branched off `main`, independent of the `el-dialog` (#51) and `el-radio-field` (#52) PRs.